### PR TITLE
Update cloelite to cloelib in pyproject.toml and dev comments

### DIFF
--- a/cloelib/cosmology/HMcode2020Emu_cosmology.py
+++ b/cloelib/cosmology/HMcode2020Emu_cosmology.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Background
 from cloelib.auxiliary.extrapolator import extend_spectra
 

--- a/cloelib/cosmology/__init__.py
+++ b/cloelib/cosmology/__init__.py
@@ -1,4 +1,4 @@
 __all__ = ['cosmology']#temporary fix, 'jax_cosmology']
 
 from cloelib.cosmology import *
-#from cloelite.cosmology.jax_cosmology import *
+#from cloelib.cosmology.jax_cosmology import *

--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.auxiliary.units import SPEED_OF_LIGHT
 from cloelib.cosmology.cosmology import Background
 

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Background
 from cloelib.cosmology.cosmology import LinearPerturbations
 from cloelib.cosmology.cosmology import NonLinearPerturbations

--- a/cloelib/observables/Comet_spectro.py
+++ b/cloelib/observables/Comet_spectro.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Background
 
 # General imports

--- a/cloelib/observables/PBJ_spectro.py
+++ b/cloelib/observables/PBJ_spectro.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Background
 
 # General imports

--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.auxiliary.units import SPEED_OF_LIGHT
 from cloelib.cosmology.cosmology import Perturbations
 from cloelib.auxiliary.math_utils import cached_stacked_simpson

--- a/cloelib/observables/spectro.py
+++ b/cloelib/observables/spectro.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Background 
 
 # General imports

--- a/cloelib/observables/tracer.py
+++ b/cloelib/observables/tracer.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.cosmology.cosmology import Perturbations
 
 # General imports

--- a/cloelib/summary_statistics/angular_two_point.py
+++ b/cloelib/summary_statistics/angular_two_point.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.observables.tracer import Tracer
 from cloelib.auxiliary.units import SPEED_OF_LIGHT
 

--- a/cloelib/summary_statistics/legendre_multiples.py
+++ b/cloelib/summary_statistics/legendre_multiples.py
@@ -1,4 +1,4 @@
-# cloelite imports
+# cloelib imports
 from cloelib.observables.spectro import SpectroPower
 from cloelib.auxiliary.math_utils import legendre, simps_jax # I made it auto-diff :) 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "cloelite"
+name = "cloelib"
 version = "0.1.0"
 description = "Proof of concept of how to make CLOE (Cosmology Likelihood for Observables in Euclid) more efficient and user-friendly by transforming it into the Cosmology Library for Observables in Euclid (compatible with classic Boltzmann Solvers and JAX)"
 authors = ["Your Name <you@example.com>"]


### PR DESCRIPTION
## Summary

- Fix package name in `pyproject.toml` such that `pip install .` works
- Update references from `cloelite` to `cloelib` in dev comments in package modules

## Notes

- I didn't touch any of the notebooks, which still contain references to `cloelite`