### PR TITLE
gh-74: clean auxiliary

### DIFF
--- a/cloelib/auxiliary/math_utils.py
+++ b/cloelib/auxiliary/math_utils.py
@@ -1,49 +1,6 @@
 import jax
 import jax.numpy as jnp
 
-# This will go to a math-utils module, for the moment stays here
-max_size = 300
-
-def simpsons_weights_odd(num_el):
-    w = jnp.zeros(num_el)
-    w = w.at[0].set(1/3)
-    w = w.at[1::2].set(4/3)
-    w = w.at[2::2].set(2/3)
-    w = w.at[-1].set(1/3)
-    return w
-
-def simpsons_weights_even(num_el):
-    num_el = int(num_el)
-    w_odd_end = simpsons_weights_odd(num_el - 1)
-    w_odd_end = w_odd_end.at[-1].add(1/6)
-    w_odd_end = jnp.append(w_odd_end, 1/6)
-
-    w_odd_start = simpsons_weights_odd(num_el - 1)
-    w_odd_start = w_odd_start.at[0].add(1/6)
-    w_odd_start = jnp.append(1/6, w_odd_start)
-
-    w_odd = (w_odd_start + w_odd_end) / 2.0
-    return w_odd
-
-def precompute_simpsons_weights(max_size):
-    weights = []
-    for n in range(1, max_size + 1):
-        if n % 2 == 1:
-            w = simpsons_weights_odd(n)
-        else:
-            w = simpsons_weights_even(n)
-        padded_w = jnp.pad(w, (0, max_size - n), constant_values=0)
-        weights.append(padded_w)
-    return jnp.array(weights)
-
- # Set this to the maximum number of elements you expect
-precomputed_weights = precompute_simpsons_weights(max_size)
-
-def get_simpsons_weights(n):
-    return precomputed_weights[n - 1]
-
-get_simpsons_weights_jit = jax.jit(get_simpsons_weights)
-
 def simpsons_weights_odd(num_el):
     w = jnp.zeros(num_el)
     w = w.at[0].set(1/3)
@@ -88,11 +45,12 @@ def stacked_simpson(n):
         rows.append(row)
     return jnp.vstack(rows)
 
-#this 100 is clearly hardcoded. Think of a better mechanism!
 _cached_stacked_simpson = {}
 
 def cached_stacked_simpson(n: int):
     key = str(n)
+    #TODO for the moment we are using a plain "if", later we are gonna need a lax conditional
+    #or a better cache mechanism
     if key not in _cached_stacked_simpson:
         _cached_stacked_simpson[key] = stacked_simpson(n)
     return _cached_stacked_simpson[key]
@@ -109,22 +67,3 @@ def legendre(n, x):
             Pn = ((2*k - 1) * x * P1 - (k - 1) * P0) / k
             P0, P1 = P1, Pn
         return Pn
-
-def simps_jax(y, x=None, dx=1.0):
-    """
-    Simpson's rule integration in JAX.
-    Parameters:
-    - y: Array of function values to integrate.
-    - x: Array of sample points corresponding to y (optional).
-    - dx: Spacing between sample points if x is None (default: 1.0).
-    """
-    N = len(y)
-    if N % 2 == 0:
-        raise ValueError("Simpson's rule requires an odd number of samples.")
-
-    if x is None:
-        x = jnp.arange(N) * dx
-
-    h = jnp.diff(x)
-    S = y[0] + y[-1] + 4 * jnp.sum(y[1:-1:2]) + 2 * jnp.sum(y[2:-2:2])
-    return (h[0] / 3) * S

--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -1,7 +1,7 @@
 # cloelib imports
 from cloelib.cosmology.cosmology import Background
 from cloelib.observables.spectro import SpectroPower
-from cloelib.auxiliary.math_utils import legendre, simps_jax
+from cloelib.auxiliary.math_utils import legendre
 
 # General imports
 from typing import Protocol, Union, TypeVar, Optional, Generic


### PR DESCRIPTION
In this PR, I have removed a couple of import that were not actually used and cleaned the math_utils module.
Specifically, previously a few numbers were hardcoded in the module (regarding the number of points used to compute the simpson integral); now these numbers were removed and a cache mechanism has been put in place.