### PR TITLE
gh-7: change of basis in jaxperturbations

### DIFF
--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -66,7 +66,7 @@ class JAXBackground:
         self.interface_args['JAXparams']['Omega_cdm'] = self.Omega_cdm0
         self.interface_args['JAXparams']['Omega_k'] = self.Omega_k0
         self.interface_args['JAXparams']['Omega_m0'] = self.Omega_m0
-        self.interface_args['JAXparams']['Omega_mnu0'] = self.Omega_mnu0
+        self.interface_args['JAXparams']['Omega_nu0'] = self.Omega_nu0
         self.interface_args['JAXparams']['n_s'] = self.ns
         self.interface_args['JAXparams']['m_ncdm'] = self.mnu
         self.interface_args['JAXparams']['A_s'] = self.As

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -566,7 +566,7 @@ class JAXNonLinearPerturbations(Perturbations):
         a_s = a_z(zs)
 
         # Compute the linear power spectrum
-        pklin = self.linearperturbations.linear_matter_power_spectrum(ks, zs)
+        pklin = self.linearperturbations.matter_power_spectrum(zs, ks)
 
         # Compute non linear scale, effective spectral index and curvature
         k_nl, n, C = self._halofit_parameters(zs)
@@ -637,7 +637,7 @@ class JAXNonLinearPerturbations(Perturbations):
         pk_nl = 2.0 * np.pi**2 / ks**3 * d2nl
         return pk_nl.squeeze()
 
-    def nonlinear_matter_power_spectrum(self, ks, zs):
+    def matter_power_spectrum(self, ks, zs):
         """Computes the non-linear matter power spectrum.
 
         This function is just a wrapper over several nonlinear power spectra.

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -460,7 +460,7 @@ class JAXLinearPerturbations:
         y = simps(int_sigma, np.log10(kmin), np.log10(kmax), N = 256)
         return 1.0 / (2.0 * np.pi**2.0) * y
 
-    def matter_power_spectrum(self, zs, ks):
+    def matter_power_spectrum(self, zs, ks,  hubble_units=False, k_hunit=False):
         r"""Computes the linear matter power spectrum.
 
         Parameters
@@ -478,7 +478,19 @@ class JAXLinearPerturbations:
             and scale factor.
 
         """
+        h = self.background.h
+
+        def k_units_case(k):
+            return k/h
+
+        def kh_units_case(k):
+            return k
+
+        conditions = np.array([k_hunit==False, k_hunit==True])
+        index = np.argwhere(conditions, size=1).squeeze()
+
         ks = np.atleast_1d(ks)
+        ks = lx.switch(index, [k_units_case, kh_units_case], ks)
         zs = np.atleast_1d(zs)
         g = self.growth_factor(zs)
         t = self.transfer_Eisenstein_Hu(ks)
@@ -489,8 +501,19 @@ class JAXLinearPerturbations:
 
         pk =  np.outer(g**2, self.primordial_matter_power(ks) * t**2)
 
+        def hMpc_units_case(h):
+            return h*h*h
+
+        def Mpc_units_case(h):
+            return 1.
+
+        conditions = np.array([hubble_units==False, hubble_units==True])
+        index = np.argwhere(conditions, size=1).squeeze()
+
+        factor = lx.switch(index, [hMpc_units_case, Mpc_units_case], h)
+
         # Apply normalisation
-        pk = pk * pknorm
+        pk = pk * pknorm/factor
         return pk.squeeze()
 
 class JAXNonLinearPerturbations(Perturbations):
@@ -559,12 +582,12 @@ class JAXNonLinearPerturbations(Perturbations):
         C = res[0] ** 2 + res[1]
         return k_nl, n_eff, C
 
-    def halofit(self, zs, ks):
+    def halofit(self, zs, ks, hubble_units=False, k_hunit=False):
         zs = np.atleast_1d(zs)
         a_s = a_z(zs)
 
         # Compute the linear power spectrum
-        pklin = self.linearperturbations.matter_power_spectrum(zs, ks)
+        pklin = self.linearperturbations.matter_power_spectrum(zs, ks, hubble_units, k_hunit)
 
         # Compute non linear scale, effective spectral index and curvature
         k_nl, n, C = self._halofit_parameters(zs)
@@ -635,13 +658,12 @@ class JAXNonLinearPerturbations(Perturbations):
         pk_nl = 2.0 * np.pi**2 / ks**3 * d2nl
         return pk_nl.squeeze()
 
-    def matter_power_spectrum(self, zs, ks):
+    def matter_power_spectrum(self, zs, ks, hubble_units=False, k_hunit=False):
         """Computes the non-linear matter power spectrum.
 
         This function is just a wrapper over several nonlinear power spectra.
         """
-        #return self.halofit(ks, zs)
-        return jax.vmap(self.halofit, in_axes = (0, None))(zs, ks)
+        return jax.vmap(self.halofit, in_axes = (0, None, None, None))(zs, ks, hubble_units, k_hunit)
 
     def nonlinear_matter_power_spectrum_limber_grid(self, z_l, ks, zs, ells):
         Pk = jax.vmap(self.nonlinear_matter_power_spectrum,

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -518,7 +518,7 @@ class JAXNonLinearPerturbations(Perturbations):
                 k = np.exp(logk)
                 r = np.exp(logr)
                 y = np.outer(k, r)
-                pk = self.linearperturbations.matter_power_spectrum(k, 0.)
+                pk = self.linearperturbations.matter_power_spectrum(0., k)
                 g = self.linearperturbations.growth_factor(np.atleast_1d(zs))
                 return (
                     np.expand_dims(pk * k**3, axis=1)
@@ -541,7 +541,7 @@ class JAXNonLinearPerturbations(Perturbations):
         def integrand(logk):
             k = np.exp(logk)
             y = np.outer(k, 1.0 / k_nl)
-            pk = self.linearperturbations.matter_power_spectrum(k, 0.)
+            pk = self.linearperturbations.matter_power_spectrum(0., k)
             g = np.expand_dims(self.linearperturbations.growth_factor(np.atleast_1d(zs)), 0)
             res = (
                 np.expand_dims(pk * k**3, axis=1)
@@ -557,10 +557,9 @@ class JAXNonLinearPerturbations(Perturbations):
 
         n_eff = res[0] - 3.0
         C = res[0] ** 2 + res[1]
-
         return k_nl, n_eff, C
 
-    def halofit(self, ks, zs):
+    def halofit(self, zs, ks):
         zs = np.atleast_1d(zs)
         a_s = a_z(zs)
 
@@ -636,12 +635,13 @@ class JAXNonLinearPerturbations(Perturbations):
         pk_nl = 2.0 * np.pi**2 / ks**3 * d2nl
         return pk_nl.squeeze()
 
-    def matter_power_spectrum(self, ks, zs):
+    def matter_power_spectrum(self, zs, ks):
         """Computes the non-linear matter power spectrum.
 
         This function is just a wrapper over several nonlinear power spectra.
         """
-        return self.halofit(ks, zs)
+        #return self.halofit(ks, zs)
+        return jax.vmap(self.halofit, in_axes = (0, None))(zs, ks)
 
     def nonlinear_matter_power_spectrum_limber_grid(self, z_l, ks, zs, ells):
         Pk = jax.vmap(self.nonlinear_matter_power_spectrum,

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -501,7 +501,6 @@ class JAXNonLinearPerturbations(Perturbations):
 
         """
         self.linearperturbations = linearperturbations
-        self.background = linearperturbations.background
 
     def _halofit_parameters(self, zs):
         r"""Computes the non linear scale,
@@ -647,7 +646,7 @@ class JAXNonLinearPerturbations(Perturbations):
     def nonlinear_matter_power_spectrum_limber_grid(self, z_l, ks, zs, ells):
         Pk = jax.vmap(self.nonlinear_matter_power_spectrum,
                       in_axes = (0, None))(ks, zs)
-        chi = self.background.comoving_distance(zs)
+        chi = self.linearperturbations.background.comoving_distance(zs)
         k_lz = np.expand_dims((ells + 0.5), 1) / chi
         Pkl = Pkl_interp_vmap(k_lz, z_l, ks, zs, Pk)
         return Pkl

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -52,6 +52,10 @@ class JAXBackground:
         self.wa = wa
         self.gamma_MG = gamma_MG
         self.mnu = mnu
+        self.sigma_8 = As_to_sigma8_max_precision(self.As, self.Omega_b0+self.Omega_cdm0+
+                                                  self.mnu/(93.14*(self.H0/100)**2),
+                                                  self.Omega_b0, self.h, self.ns, 0.,
+                                                  self.w0, self.wa)
 
         # Initialize JaxBgk parameters
         self.interface_args = {'JAXparams': {}}  # Use a dictionary for CLASS parameters
@@ -64,6 +68,7 @@ class JAXBackground:
         self.interface_args['JAXparams']['A_s'] = self.As
         self.interface_args['JAXparams']['w0_fld'] = self.w0 # or w0
         self.interface_args['JAXparams']['wa_fld'] = self.wa # or wa
+        self.interface_args['JAXparams']['sigma_8'] = self.wa # or wa
 
     @property
     def _interface_args(self) -> dict:
@@ -193,14 +198,17 @@ class JAXBackground:
         Omega_nu0 = self.mnu/(93.14*(self.H0/100)**2)
         return np.array([(self.Omega_b0+self.Omega_cdm0+Omega_nu0) * (1+z)**3 /(self.hubble_parameter(z)/self.H0)**2  for z in zs])
 
-class JAXLinearPerturbations(Perturbations):
-    def __init__(self, background : Background):
-        r"""
-        A class to define perturbations cosmology using JAX
-        and inheriting from Cosmology parent class
+class JAXLinearPerturbations:
+    def __init__(self, background: Background, redshifts: np.ndarray) -> None:
+        """
+        Initializes the JAXLinearPerturbations class with a background instance.
 
+        Args:
+            background (Background): A Background instance.
+            redshifts (np.ndarray): Array of redshifts for the calculations.
         """
         self.background = background
+        self.z = redshifts
 
     def w_a(self, a):
         return self.background.w + (1.0 - a) * self.background.wa  # Equation (6) in Linder (2003)
@@ -449,23 +457,19 @@ class JAXLinearPerturbations(Perturbations):
             pk = self.transfer_Eisenstein_Hu(k) ** 2 * self.primordial_matter_power(k)
             return k * (k * w) ** 2 * pk
 
-        #y = romb(int_sigma, np.log10(kmin), np.log10(kmax), divmax=7)
         y = simps(int_sigma, np.log10(kmin), np.log10(kmax), N = 256)
         return 1.0 / (2.0 * np.pi**2.0) * y
 
-    def linear_matter_power_spectrum(self, ks, zs, **kwargs):
+    def matter_power_spectrum(self, zs, ks, **kwargs):
         r"""Computes the linear matter power spectrum.
 
         Parameters
         ----------
-        k: array_like
-            Wave number in h Mpc^{-1}
-
         zs: array_like, optional
             Redshifts
 
-        transfer_fn: transfer_fn(cosmo, k, **kwargs)
-            Transfer function
+        k: array_like
+            Wave number in h Mpc^{-1}
 
         Returns
         -------
@@ -851,3 +855,51 @@ def Pkl_interp(k_l, z_l, ks, zs, Pk):
                                  method="cubic")
 
 Pkl_interp_vmap = jax.jit(jax.vmap(Pkl_interp, in_axes=(0, None, None, None, None)))
+
+#from 2410.14623
+def As_to_sigma8_max_precision(As, Om, Ob, h, ns, mnu, w0, wa):
+    """
+    Compute the emulated conversion As -> sigma8, using the most accurate expression
+
+    Args:
+        :As (float): 10^9 times the amplitude of the primordial P(k)
+        :Om (float): The z=0 total matter density parameter, Om
+        :Ob (float): The z=0 baryonic density parameter, Ob
+        :h (float): Hubble constant, H0, divided by 100 km/s/Mpc
+        :ns (float): Spectral tilt of primordial power spectrum
+        :mnu (float): Sum of neutrino masses [eV / c^2]
+        :w0 (float): Time independent part of the dark energy EoS
+        :wa (float): Time dependent part of the dark energy EoS
+
+    Returns:
+        :sigma8 (float): Root-mean-square density fluctuation when the linearly
+            evolved field is smoothed with a top-hat filter of radius 8 Mpc/h
+    """
+
+    b = np.array([0.0246, 2.1062, 2.9355, 0.7626, 0.2962, 0.5096,
+                4.4025, 3.6495, 0.4144, 0.8615, 0.6188, 0.1751,
+                0.824, 0.5466, 0.5519, 0.3689, 0.3261, 0.2002,
+                0.8892, 0.4462, 1.215, 3.4829, 2.5852, 0.0242,
+                0.0051, 0.1614, 1.2991, 4.1426, 3.3055, 0.5716,
+                6.0094, 1.9569, 2.1477, 1.1902, 0.128, 0.6931,
+                0.2661])
+
+    term1_inner = (Om * b[1] +
+                (b[2] * mnu - b[3] * ns + np.log(b[4] * h - b[5] * mnu)) *
+                (b[6] * h + b[7] * mnu - b[8] * ns + 1))
+    term1 = b[0] * term1_inner
+
+    term2 = b[9] * h - mnu
+
+    term3_inner1 = (b[12] * w0 - b[13] * wa - np.log(Om * b[14])) * \
+                (Om * b[15] + b[16] * w0 + b[17] * wa + np.log(-b[18] * w0 - b[19] * wa))
+    term3_inner2 = np.log(Om * b[20] + np.log(-b[21] * w0 - b[22] * wa))
+    term3 = b[10] * w0 - b[11] * mnu - term3_inner1 - term3_inner2 + np.log(-b[23] * w0 - b[24] * wa)
+
+    term4_inner1 = Ob * b[30] - b[31] * h - np.log(Om * b[32])
+    term4_inner2 = Om * b[33] - b[34] * h - b[35] * mnu - b[36] * ns
+    term4 = b[25] * mnu - np.sqrt(Ob) * b[26] - Ob * b[27] + Om * b[28] - b[29] * h + 1 + term4_inner1 * term4_inner2
+
+    result = term1 * term2 * term3 * term4
+
+    return result*np.sqrt(As)

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -487,7 +487,7 @@ class JAXLinearPerturbations:
         # this means we have a 0.01% difference compared to the romberg calculation,
         # but it is much faster
 
-        pk =  np.outer(self.primordial_matter_power(ks) * t**2,  g**2)
+        pk =  np.outer(g**2, self.primordial_matter_power(ks) * t**2)
 
         # Apply normalisation
         pk = pk * pknorm
@@ -901,4 +901,4 @@ def As_to_sigma8_max_precision(As, Om, Ob, h, ns, mnu, w0, wa):
 
     result = term1 * term2 * term3 * term4
 
-    return result*np.sqrt(As)
+    return result*np.sqrt(As*10**9)

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -211,23 +211,23 @@ class JAXLinearPerturbations:
         self.z = redshifts
 
     def w_a(self, a):
-        return self.background.w + (1.0 - a) * self.background.wa  # Equation (6) in Linder (2003)
+        return self.background.w0 + (1.0 - a) * self.background.wa  # Equation (6) in Linder (2003)
 
     def f_de(self, a):
-        return -3.0 * (1.0 + self.background.w + self.background.wa) * np.log(a) + 3.0 * self.background.wa * (a - 1.0)
+        return -3.0 * (1.0 + self.background.w0 + self.background.wa) * np.log(a) + 3.0 * self.background.wa * (a - 1.0)
 
     def Esqr(self, a):
-        Omm = self.background.Omb + self.background.Omc
-        OmDE = 1. - Omm - self.background.Omk
-        return (Omm * np.power(a, -3) + self.background.Omk * np.power(a, -2)
+        Omm = self.background.Omega_b0 + self.background.Omega_cdm0
+        OmDE = 1. - Omm - self.background.Omega_k0
+        return (Omm * np.power(a, -3) + self.background.Omega_k0 * np.power(a, -2)
                 + OmDE * np.exp(self.f_de(a)))
 
     def Omega_m_a(self, a):
-        Omm = self.background.Omb + self.background.Omc
+        Omm = self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2)
         return Omm * np.power(a, -3) / self.Esqr(a)
 
     def Omega_de_a(self, a):
-        OmDE = 1. - self.background.Omb - self.background.Omc - self.background.Omk
+        OmDE = 1. - self.background.Omega_b0 - self.background.Omega_cdm0 - self.background.mnu/(93.14*(self.H0/100)**2) - self.background.Omega_k0
         return OmDE * np.exp(self.f_de(a)) / self.Esqr(a)
 
     def D_derivs(self, y, x):
@@ -308,10 +308,10 @@ class JAXLinearPerturbations:
         T_2_7_sqr = (2.726 / 2.7) ** 2
         h2 = (self.background.H0/100) ** 2
 
-        w_m = (self.background.Omc + self.background.Omb) * h2
-        w_b = self.background.Omb * h2
-        fb = self.background.Omb / (self.background.Omc + self.background.Omb)
-        fc = self.background.Omc / (self.background.Omc + self.background.Omb)
+        w_m = (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2)) * h2
+        w_b = self.background.Omega_b0 * h2
+        fb = self.background.Omega_b0 / (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2))
+        fc = (self.background.Omega_cdm0+self.background.mnu/(93.14*(self.H0/100)**2)) / (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2))
 
         k_eq = 7.46e-2 * w_m / T_2_7_sqr / (self.background.H0/100)  # Eq. (3) [h/Mpc]
         z_eq = 2.50e4 * w_m / (T_2_7_sqr) ** 2  # Eq. (2)
@@ -350,9 +350,9 @@ class JAXLinearPerturbations:
         alpha_gamma = (
             1.0
             - 0.328 * np.log(431.0 * w_m) * w_b / w_m
-            + 0.38 * np.log(22.3 * w_m) * (self.background.Omb/ (self.background.Omc + self.background.Omb)) ** 2
+            + 0.38 * np.log(22.3 * w_m) * (self.background.Omega_b0/ (self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.H0/100)**2))) ** 2
         )
-        gamma_eff = ((self.background.Omc + self.background.Omb)
+        gamma_eff = ((self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.H0/100)**2))
             * (self.background.H0/100)
             * (alpha_gamma + (1.0 - alpha_gamma) / (1.0 + (0.43 * ks * sh_d) ** 4))
         )
@@ -460,7 +460,7 @@ class JAXLinearPerturbations:
         y = simps(int_sigma, np.log10(kmin), np.log10(kmax), N = 256)
         return 1.0 / (2.0 * np.pi**2.0) * y
 
-    def matter_power_spectrum(self, zs, ks, **kwargs):
+    def matter_power_spectrum(self, zs, ks):
         r"""Computes the linear matter power spectrum.
 
         Parameters

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -208,7 +208,7 @@ class JAXBackground:
         return -3.0 * (1.0 + self.w0 + self.wa) * np.log(a) + 3.0 * self.wa * (a - 1.0)
 
     def Esqr(self, a):
-        OmDE = 1. - self.Omega_m0 - self.background.Omega_k0
+        OmDE = 1. - self.Omega_m0 - self.Omega_k0
         return (self.Omega_m0 * np.power(a, -3) + self.Omega_k0 * np.power(a, -2)
                 + OmDE * np.exp(self.f_de(a)))
 
@@ -351,7 +351,7 @@ class JAXLinearPerturbations:
         alpha_gamma = (
             1.0
             - 0.328 * np.log(431.0 * w_m) * w_b / w_m
-            + 0.38 * np.log(22.3 * w_m) * (self.background.Omega_b0/ (self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.H0/100)**2))) ** 2
+            + 0.38 * np.log(22.3 * w_m) * (self.background.Omega_b0/ (self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.background.H0/100)**2))) ** 2
         )
         gamma_eff = ((self.background.Omega_m0) * (self.background.h)
             * (alpha_gamma + (1.0 - alpha_gamma) / (1.0 + (0.43 * ks * sh_d) ** 4))
@@ -483,7 +483,7 @@ class JAXLinearPerturbations:
         g = self.growth_factor(zs)
         t = self.transfer_Eisenstein_Hu(ks)
 
-        pknorm = self.background.sigma8**2 / self.sigma8sqr()#previously self.sigmasqr(8.0)
+        pknorm = self.background.sigma_8**2 / self.sigma8sqr()#previously self.sigmasqr(8.0)
         # this means we have a 0.01% difference compared to the romberg calculation,
         # but it is much faster
 
@@ -518,7 +518,7 @@ class JAXNonLinearPerturbations(Perturbations):
                 k = np.exp(logk)
                 r = np.exp(logr)
                 y = np.outer(k, r)
-                pk = self.linearperturbations.linear_matter_power_spectrum(k, 0.)
+                pk = self.linearperturbations.matter_power_spectrum(k, 0.)
                 g = self.linearperturbations.growth_factor(np.atleast_1d(zs))
                 return (
                     np.expand_dims(pk * k**3, axis=1)
@@ -541,7 +541,7 @@ class JAXNonLinearPerturbations(Perturbations):
         def integrand(logk):
             k = np.exp(logk)
             y = np.outer(k, 1.0 / k_nl)
-            pk = self.linearperturbations.linear_matter_power_spectrum(k, 0.)
+            pk = self.linearperturbations.matter_power_spectrum(k, 0.)
             g = np.expand_dims(self.linearperturbations.growth_factor(np.atleast_1d(zs)), 0)
             res = (
                 np.expand_dims(pk * k**3, axis=1)
@@ -646,7 +646,7 @@ class JAXNonLinearPerturbations(Perturbations):
     def nonlinear_matter_power_spectrum_limber_grid(self, z_l, ks, zs, ells):
         Pk = jax.vmap(self.nonlinear_matter_power_spectrum,
                       in_axes = (0, None))(ks, zs)
-        chi = self.linearperturbations.background.comoving_distance(zs)
+        chi = self.linearperturbations.linearperturbations.background.comoving_distance(zs)
         k_lz = np.expand_dims((ells + 0.5), 1) / chi
         Pkl = Pkl_interp_vmap(k_lz, z_l, ks, zs, Pk)
         return Pkl

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -201,6 +201,24 @@ class JAXBackground:
         """
         return np.array([(self.Omega_m0) * (1+z)**3 /(self.hubble_parameter(z)/self.H0)**2  for z in zs])
 
+    def w_a(self, a):
+        return self.w0 + (1.0 - a) * self.wa  # Equation (6) in Linder (2003)
+
+    def f_de(self, a):
+        return -3.0 * (1.0 + self.w0 + self.wa) * np.log(a) + 3.0 * self.wa * (a - 1.0)
+
+    def Esqr(self, a):
+        OmDE = 1. - self.Omega_m0 - self.background.Omega_k0
+        return (self.Omega_m0 * np.power(a, -3) + self.Omega_k0 * np.power(a, -2)
+                + OmDE * np.exp(self.f_de(a)))
+
+    def Omega_m_a(self, a):
+        return self.Omega_m0 * np.power(a, -3) / self.Esqr(a)
+
+    def Omega_de_a(self, a):
+        OmDE = 1. - self.Omega_m0 - self.Omega_k0
+        return OmDE * np.exp(self.f_de(a)) / self.Esqr(a)
+
 class JAXLinearPerturbations:
     def __init__(self, background: Background, redshifts: np.ndarray) -> None:
         """
@@ -213,28 +231,10 @@ class JAXLinearPerturbations:
         self.background = background
         self.z = redshifts
 
-    def w_a(self, a):
-        return self.background.w0 + (1.0 - a) * self.background.wa  # Equation (6) in Linder (2003)
-
-    def f_de(self, a):
-        return -3.0 * (1.0 + self.background.w0 + self.background.wa) * np.log(a) + 3.0 * self.background.wa * (a - 1.0)
-
-    def Esqr(self, a):
-        OmDE = 1. - self.background.Omega_m0 - self.background.Omega_k0
-        return (self.background.Omega_m0 * np.power(a, -3) + self.background.Omega_k0 * np.power(a, -2)
-                + OmDE * np.exp(self.f_de(a)))
-
-    def Omega_m_a(self, a):
-        return self.background.Omega_m0 * np.power(a, -3) / self.Esqr(a)
-
-    def Omega_de_a(self, a):
-        OmDE = 1. - self.background.Omega_m0 - self.background.Omega_k0
-        return OmDE * np.exp(self.f_de(a)) / self.Esqr(a)
-
     def D_derivs(self, y, x):
-            q = (2.0 - 0.5* ( self.Omega_m_a(x) + (1.0 + 3.0 * self.w_a(x)) *
-                             self.Omega_de_a(x))) / x
-            r = 1.5 * self.Omega_m_a(x) / x / x
+            q = (2.0 - 0.5* ( self.background.Omega_m_a(x) + (1.0 + 3.0 * self.background.w_a(x)) *
+                             self.background.Omega_de_a(x))) / x
+            r = 1.5 * self.background.Omega_m_a(x) / x / x
             return np.array([y[1], -q * y[1] + r * y[0]])
 
     def growth_factor(self, zs):
@@ -571,9 +571,9 @@ class JAXNonLinearPerturbations(Perturbations):
         # Compute non linear scale, effective spectral index and curvature
         k_nl, n, C = self._halofit_parameters(zs)
 
-        om_m = self.linearperturbations.Omega_m_a(a_s)
-        om_de = self.linearperturbations.Omega_de_a(a_s)
-        w = self.linearperturbations.w_a(a_s)
+        om_m = self.linearperturbations.background.Omega_m_a(a_s)
+        om_de = self.linearperturbations.background.Omega_de_a(a_s)
+        w = self.linearperturbations.background.w_a(a_s)
         frac = om_de / (1.0 - om_m)
 
         a_n = 10 ** (

--- a/cloelib/cosmology/jax_cosmology.py
+++ b/cloelib/cosmology/jax_cosmology.py
@@ -52,8 +52,10 @@ class JAXBackground:
         self.wa = wa
         self.gamma_MG = gamma_MG
         self.mnu = mnu
-        self.sigma_8 = As_to_sigma8_max_precision(self.As, self.Omega_b0+self.Omega_cdm0+
-                                                  self.mnu/(93.14*(self.H0/100)**2),
+        self.Omega_nu0 = self.mnu/(93.14*(self.h)**2)#this is a semplification, we are assuming
+        #neutrinos are non relativistic
+        self.Omega_m0 = self.Omega_b0+self.Omega_cdm0+self.Omega_nu0
+        self.sigma_8 = As_to_sigma8_max_precision(self.As, self.Omega_m0,
                                                   self.Omega_b0, self.h, self.ns, 0.,
                                                   self.w0, self.wa)
 
@@ -63,12 +65,14 @@ class JAXBackground:
         self.interface_args['JAXparams']['Omega_b'] = self.Omega_b0
         self.interface_args['JAXparams']['Omega_cdm'] = self.Omega_cdm0
         self.interface_args['JAXparams']['Omega_k'] = self.Omega_k0
+        self.interface_args['JAXparams']['Omega_m0'] = self.Omega_m0
+        self.interface_args['JAXparams']['Omega_mnu0'] = self.Omega_mnu0
         self.interface_args['JAXparams']['n_s'] = self.ns
         self.interface_args['JAXparams']['m_ncdm'] = self.mnu
         self.interface_args['JAXparams']['A_s'] = self.As
         self.interface_args['JAXparams']['w0_fld'] = self.w0 # or w0
         self.interface_args['JAXparams']['wa_fld'] = self.wa # or wa
-        self.interface_args['JAXparams']['sigma_8'] = self.wa # or wa
+        self.interface_args['JAXparams']['sigma_8'] = self.sigma_8 # or wa
 
     @property
     def _interface_args(self) -> dict:
@@ -195,8 +199,7 @@ class JAXBackground:
         Returns:
             np.ndarray: Matter density values.
         """
-        Omega_nu0 = self.mnu/(93.14*(self.H0/100)**2)
-        return np.array([(self.Omega_b0+self.Omega_cdm0+Omega_nu0) * (1+z)**3 /(self.hubble_parameter(z)/self.H0)**2  for z in zs])
+        return np.array([(self.Omega_m0) * (1+z)**3 /(self.hubble_parameter(z)/self.H0)**2  for z in zs])
 
 class JAXLinearPerturbations:
     def __init__(self, background: Background, redshifts: np.ndarray) -> None:
@@ -217,17 +220,15 @@ class JAXLinearPerturbations:
         return -3.0 * (1.0 + self.background.w0 + self.background.wa) * np.log(a) + 3.0 * self.background.wa * (a - 1.0)
 
     def Esqr(self, a):
-        Omm = self.background.Omega_b0 + self.background.Omega_cdm0
-        OmDE = 1. - Omm - self.background.Omega_k0
-        return (Omm * np.power(a, -3) + self.background.Omega_k0 * np.power(a, -2)
+        OmDE = 1. - self.background.Omega_m0 - self.background.Omega_k0
+        return (self.background.Omega_m0 * np.power(a, -3) + self.background.Omega_k0 * np.power(a, -2)
                 + OmDE * np.exp(self.f_de(a)))
 
     def Omega_m_a(self, a):
-        Omm = self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2)
-        return Omm * np.power(a, -3) / self.Esqr(a)
+        return self.background.Omega_m0 * np.power(a, -3) / self.Esqr(a)
 
     def Omega_de_a(self, a):
-        OmDE = 1. - self.background.Omega_b0 - self.background.Omega_cdm0 - self.background.mnu/(93.14*(self.H0/100)**2) - self.background.Omega_k0
+        OmDE = 1. - self.background.Omega_m0 - self.background.Omega_k0
         return OmDE * np.exp(self.f_de(a)) / self.Esqr(a)
 
     def D_derivs(self, y, x):
@@ -308,12 +309,12 @@ class JAXLinearPerturbations:
         T_2_7_sqr = (2.726 / 2.7) ** 2
         h2 = (self.background.H0/100) ** 2
 
-        w_m = (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2)) * h2
+        w_m = (self.background.Omega_m0) * h2
         w_b = self.background.Omega_b0 * h2
-        fb = self.background.Omega_b0 / (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2))
-        fc = (self.background.Omega_cdm0+self.background.mnu/(93.14*(self.H0/100)**2)) / (self.background.Omega_b0 + self.background.Omega_cdm0 + self.background.mnu/(93.14*(self.H0/100)**2))
+        fb = self.background.Omega_b0 / (self.background.Omega_m0)
+        fc = (self.background.Omega_cdm0+self.background.Omega_nu0) / (self.background.Omega_m0)
 
-        k_eq = 7.46e-2 * w_m / T_2_7_sqr / (self.background.H0/100)  # Eq. (3) [h/Mpc]
+        k_eq = 7.46e-2 * w_m / T_2_7_sqr / (self.background.h)  # Eq. (3) [h/Mpc]
         z_eq = 2.50e4 * w_m / (T_2_7_sqr) ** 2  # Eq. (2)
 
         # z drag from Eq. (4)
@@ -343,7 +344,7 @@ class JAXLinearPerturbations:
             * np.power(w_b, 0.52)
             * np.power(w_m, 0.73)
             * (1.0 + np.power(10.4 * w_m, -0.95))
-            / (self.background.H0/100)
+            / (self.background.h)
         )
         #############################################
 
@@ -352,8 +353,7 @@ class JAXLinearPerturbations:
             - 0.328 * np.log(431.0 * w_m) * w_b / w_m
             + 0.38 * np.log(22.3 * w_m) * (self.background.Omega_b0/ (self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.H0/100)**2))) ** 2
         )
-        gamma_eff = ((self.background.Omega_cdm0 + self.background.Omega_b0 + self.background.mnu/(93.14*(self.H0/100)**2))
-            * (self.background.H0/100)
+        gamma_eff = ((self.background.Omega_m0) * (self.background.h)
             * (alpha_gamma + (1.0 - alpha_gamma) / (1.0 + (0.43 * ks * sh_d) ** 4))
         )
 


### PR DESCRIPTION
The goal of this PR is to deal with the last missing piece in our JAX implementations: the perturbations.
I have slightly changed the constructor of the background: given the same previous argument, the constructor will also evaluate a bunch of derived parameters, that are required for the calculations performed afterwords.

Closes #7 