### PR TITLE
gh-140: Added function to compute the Legendre multipoles of a specific diagr…

### DIFF
--- a/cloelib/observables/CometEFT_spectro.py
+++ b/cloelib/observables/CometEFT_spectro.py
@@ -82,31 +82,31 @@ class CometEFT_SpectroPower:
             comet_inst.P2d_nostoch(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
                                    params=self.parameters, de_model='w0wa'))
 
-    def Pk2d_X_rsd(self, k: np.ndarray, mu: np.ndarray, X_list: list) -> np.ndarray:
-        r"""2D power spectrum for the specific diagram X of the loop expansion
+    def Pk2d_term_rsd(self, k: np.ndarray, mu: np.ndarray, term_list: list) -> np.ndarray:
+        r"""2D power spectrum for a subset of specific diagrams of the loop expansion
         Parameters
         ----------
         k: np.ndarray
             Wavenumber
         mu: np.ndarray
             Angle (cosinus) to the line of sight
-        X: list
+        term_list: list
             Identifiers of loop diagrams
         Returns
         -------
-        PX2d_rsd: np.ndarray
-            2D power spectrum of term X
+        Pk2d_term_rsd: np.ndarray
+            2D power spectrum of specific terms
         """
-        X_list_expanded, index_map = [], {}
-        for key in X_list:
+        term_list_expanded, index_map = [], {}
+        for key in term_list:
             vals = self.diagram_naming_relation[key]
             vals = vals if isinstance(vals, list) else [vals]
-            index_map[key] = list(range(len(X_list_expanded),
-                                  len(X_list_expanded) + len(vals)))
-            X_list_expanded.extend(vals)
+            index_map[key] = list(range(len(term_list_expanded),
+                                  len(term_list_expanded) + len(vals)))
+            term_list_expanded.extend(vals)
         Pk2d_expanded = np.squeeze(
             comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
-                             params=self.parameters, X_list=X_list_expanded,
+                             params=self.parameters, X_list=term_list_expanded,
                              de_model='w0wa'), axis=-1)
         Pk2d = np.array(
             [np.sum(Pk2d_expanded[indices], axis=0)

--- a/cloelib/observables/CometEFT_spectro.py
+++ b/cloelib/observables/CometEFT_spectro.py
@@ -55,6 +55,16 @@ class CometEFT_SpectroPower:
 
         self.redshift = redshift
 
+        self.diagram_naming_relation = {
+            'b1-b1': ['P0L_b1b1', 'P1L_b1b1'],
+            'b1-b2': 'P1L_b1b2', 'b1-bG2': 'P1L_b1g2', 'b1-bGam3': 'P1L_b1g21',
+            'b2-b2': 'P1L_b2b2', 'b2-bG2': 'P1L_b2g2', 'bG2-bG2': 'P1L_g2g2',
+            'b1': 'PNL_b1', 'b2': 'P1L_b2', 'bG2': 'P1L_g2', 'bGam3': 'P1L_g21',
+            'v-v': 'PNL_id',
+            'c0': 'Pctr_c0', 'c2': 'Pctr_c2', 'c4': 'Pctr_c4',
+            'b1-b1-cnlo': 'Pctr_b1b1cnlo', 'b1-cnlo': 'Pctr_b1cnlo', 'cnlo': 'Pctr_cnlo'
+        }
+
     def Pk2d_rsd(self, k: np.ndarray, mu: np.ndarray) -> np.ndarray:
         r"""2D power spectrum from couplings of density and velocity fields
         Parameters
@@ -87,7 +97,19 @@ class CometEFT_SpectroPower:
         PX2d_rsd: np.ndarray
             2D power spectrum of term X
         """
-        Pk2d = comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
-                                params=self.parameters, X_list=X_list,
-                                de_model='w0wa')
-        return np.squeeze(Pk2d)
+        X_list_expanded, index_map = [], {}
+        for key in X_list:
+            vals = self.diagram_naming_relation[key]
+            vals = vals if isinstance(vals, list) else [vals]
+            index_map[key] = list(range(len(X_list_expanded),
+                                  len(X_list_expanded) + len(vals)))
+            X_list_expanded.extend(vals)
+        Pk2d_expanded = np.squeeze(
+            comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
+                             params=self.parameters, X_list=X_list_expanded,
+                             de_model='w0wa'), axis=-1)
+        Pk2d = np.array(
+            [np.sum(Pk2d_expanded[indices], axis=0)
+             if len(indices) > 1 else Pk2d_expanded[indices[0]]
+             for key, indices in index_map.items()])
+        return Pk2d

--- a/cloelib/observables/CometVDG_spectro.py
+++ b/cloelib/observables/CometVDG_spectro.py
@@ -102,31 +102,31 @@ class CometVDG_SpectroPower:
         Winfty = self._Winfty(k=k, mu=mu)
         return Pk2d * Winfty
 
-    def Pk2d_X_rsd(self, k: np.ndarray, mu: np.ndarray, X_list: list) -> np.ndarray:
-        r"""2D power spectrum for the specific diagram X of the loop expansion
+    def Pk2d_term_rsd(self, k: np.ndarray, mu: np.ndarray, term_list: list) -> np.ndarray:
+        r"""2D power spectrum for a subset of specific diagrams of the loop expansion
         Parameters
         ----------
         k: np.ndarray
             Wavenumber
         mu: np.ndarray
             Angle (cosinus) to the line of sight
-        X: list
+        term_list: list
             Identifiers of loop diagrams
         Returns
         -------
-        PX2d_rsd: np.ndarray
-            2D power spectrum of term X
+        Pk2d_term_rsd: np.ndarray
+            2D power spectrum of specific terms
         """
-        X_list_expanded, index_map = [], {}
-        for key in X_list:
+        term_list_expanded, index_map = [], {}
+        for key in term_list:
             vals = self.diagram_naming_relation[key]
             vals = vals if isinstance(vals, list) else [vals]
-            index_map[key] = list(range(len(X_list_expanded),
-                                  len(X_list_expanded) + len(vals)))
-            X_list_expanded.extend(vals)
+            index_map[key] = list(range(len(term_list_expanded),
+                                  len(term_list_expanded) + len(vals)))
+            term_list_expanded.extend(vals)
         Pk2d_expanded = np.squeeze(
             comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
-                             params=self.parameters, X_list=X_list_expanded,
+                             params=self.parameters, X_list=term_list_expanded,
                              de_model='w0wa'), axis=-1)
         Pk2d = np.array(
             [np.sum(Pk2d_expanded[indices], axis=0)

--- a/cloelib/observables/CometVDG_spectro.py
+++ b/cloelib/observables/CometVDG_spectro.py
@@ -54,6 +54,15 @@ class CometVDG_SpectroPower:
 
         self.redshift = redshift
 
+        self.diagram_naming_relation = {
+            'b1-b1': ['P0L_b1b1', 'P1L_b1b1'],
+            'b1-b2': 'P1L_b1b2', 'b1-bG2': 'P1L_b1g2', 'b1-bGam3': 'P1L_b1g21',
+            'b2-b2': 'P1L_b2b2', 'b2-bG2': 'P1L_b2g2', 'bG2-bG2': 'P1L_g2g2',
+            'b1': 'PNL_b1', 'b2': 'P1L_b2', 'bG2': 'P1L_g2', 'bGam3': 'P1L_g21',
+            'v-v': 'PNL_id',
+            'c0': 'Pctr_c0', 'c2': 'Pctr_c2', 'c4': 'Pctr_c4'
+        }
+
     def _Winfty(self, k: np.ndarray, mu: np.ndarray) -> np.ndarray:
         r"""Large-scale limit of the velocity difference generating function
         Parameters
@@ -108,8 +117,20 @@ class CometVDG_SpectroPower:
         PX2d_rsd: np.ndarray
             2D power spectrum of term X
         """
-        Pk2d = comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
-                                params=self.parameters, X_list=X_list,
-                                de_model='w0wa')
+        X_list_expanded, index_map = [], {}
+        for key in X_list:
+            vals = self.diagram_naming_relation[key]
+            vals = vals if isinstance(vals, list) else [vals]
+            index_map[key] = list(range(len(X_list_expanded),
+                                  len(X_list_expanded) + len(vals)))
+            X_list_expanded.extend(vals)
+        Pk2d_expanded = np.squeeze(
+            comet_inst.PX_2d(k=k[:, :, np.newaxis], mu=mu[:, np.newaxis],
+                             params=self.parameters, X_list=X_list_expanded,
+                             de_model='w0wa'), axis=-1)
+        Pk2d = np.array(
+            [np.sum(Pk2d_expanded[indices], axis=0)
+             if len(indices) > 1 else Pk2d_expanded[indices[0]]
+             for key, indices in index_map.items()])
         Winfty = self._Winfty(k=k, mu=mu)
-        return np.einsum('abc,bc->abc', np.squeeze(Pk2d), Winfty)
+        return np.einsum('abc,bc->abc', Pk2d, Winfty)

--- a/cloelib/observables/spectro.py
+++ b/cloelib/observables/spectro.py
@@ -31,19 +31,17 @@ class SpectroPower(Protocol):
         """
         ...
 
-    def Pk2d_X_rsd(self, k: T, mu: T, **args) -> T:
-        r"""2D power spectrum for the specific diagram X of the loop expansion
+    def Pk2d_term_rsd(self, k: T, mu: T, **args) -> T:
+        r"""2D power spectrum for a subset of specific term of the loop expansion
         Parameters
         ----------
         k: numpy.ndarray or jax.numpy.ndarray
             Wavenumber
         mu: numpy.ndarray or jax.numpy.ndarray
             Angle (cosinus) to the line of sight
-        X: str
-            Identifier of loop diagram
         Returns
         -------
-        Pk2d_X_rsd: numpy.ndarray or jax.numpy.ndarray
-            2D power spectrum of term X
+        Pk2d_term_rsd: numpy.ndarray or jax.numpy.ndarray
+            2D power spectrum of specific terms
         """
         ...

--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -50,7 +50,6 @@ class LegendreMultipoles:
         self.parameters = parameters
         self.nbar = nbar
 
-
     def _q_AP_tr(self, zs: np.ndarray) -> np.ndarray:
         r"""AP distortion parameter transversal to the line of sight
         .. math::
@@ -169,9 +168,55 @@ class LegendreMultipoles:
         Pk2d_noise: np.ndarray
             2D power spectrum from expansion of stochastic field
         """
-        noise = self.parameters['NP0'] + k**2 * (self.parameters['NP20'] +
-                                                 self.parameters['NP22'] *
-                                                 legendre(2, mu))
+        noise = (self.parameters['NP0'] * self._Pk2d_noise_k0(k)
+                 + self.parameters['NP20'] * self._Pk2d_noise_k0(k)
+                 + self.parameters['NP22'] * self._Pk2d_noise_k2mu2(k, mu))
+        return noise
+
+    def _Pk2d_noise_k0(self, k: np.ndarray) -> np.ndarray:
+        r"""Leading-order term from 2d power spectrum of stochastic field
+        Parameters
+        ----------
+        k: np.ndarray
+            Wavenumber
+        Returns
+        -------
+        noise: np.ndarray
+            2D power spectrum from expansion of stochastic field
+        """
+        noise = np.full_like(k, 1.0)
+        return noise / self.nbar
+
+    def _Pk2d_noise_k2(self, k: np.ndarray) -> np.ndarray:
+        r"""Isotropic next-to-leading-order term from 2d power spectrum of
+        stochastic field
+        Parameters
+        ----------
+        k: np.ndarray
+            Wavenumber
+        Returns
+        -------
+        noise: np.ndarray
+            2D power spectrum from expansion of stochastic field
+        """
+        noise = k**2
+        return noise / self.nbar
+
+    def _Pk2d_noise_k2mu2(self, k: np.ndarray, mu: np.ndarray) -> np.ndarray:
+        r"""Anisotropic next-to-leading-order term from 2d power spectrum of
+        stochastic field
+        Parameters
+        ----------
+        k: np.ndarray
+            Wavenumber
+        mu: np.ndarray
+            Angle (cosinus) to the line of sight
+        Returns
+        -------
+        noise: np.ndarray
+            2D power spectrum from expansion of stochastic field
+        """
+        noise = k**2 * legendre(2, mu)
         return noise / self.nbar
 
     def _Pk2d_tot(self, k: np.ndarray, mu: np.ndarray) -> np.ndarray:
@@ -225,6 +270,50 @@ class LegendreMultipoles:
                                                            use_AP=use_AP)) *
                                 legendre(ell, self.mu_grid),
                                 self.mu_grid, axis=1)
+            multipoles[f'ell{ell}'] *= (2.0 * prefactors[i])
+        return multipoles
+
+    def power_X_multipoles(self, k: np.ndarray, X_list: list,
+                           ells: Optional[np.ndarray] = None,
+                           use_AP: Optional[bool] = True) -> dict:
+        r"""Power spectrum Legendre multipoles
+        Parameters
+        ----------
+        k: np.ndarray
+            Wavenumber
+        ells: np.ndarray
+            Legendre multipole order
+        use_AP: bool
+            Flag to switch between with and without AP corrections
+        Returns
+        -------
+        multipoles: dict
+            Power spectrum Legendre multipoles
+        """
+        ells = self._ensure_array(ells) if ells is not None else np.array([0,2,4])
+        AP_factor = (self._q_AP_tr(self.redshift)**2 *
+                     self._q_AP_lo(self.redshift) if use_AP else 1.0)
+        prefactors = np.array([(2.0 * m + 1.0) for m in ells]) / 2.0 / \
+            AP_factor
+        Pk2d = np.empty((len(X_list), len(k), len(self.mu_grid)))
+        rsd_ids = [id for id, term in enumerate(X_list) if 'noise' not in term]
+        kAP = self._k_AP(k, self.mu_grid, self.redshift, use_AP=use_AP)
+        muAP = self._mu_AP(self.mu_grid, self.redshift, use_AP=use_AP)
+        Pk2d[rsd_ids] = self.spectro_power.Pk2d_X_rsd(
+            kAP, muAP, X_list=[X_list[id] for id in rsd_ids])
+        noise_ids = [id for id in range(len(X_list)) if id not in rsd_ids]
+        noise_func = {'noise_k0': self._Pk2d_noise_k0,
+                      'noise_k2': self._Pk2d_noise_k2,
+                      'noise_k2mu2': self._Pk2d_noise_k2mu2}
+        if noise_ids:
+            Pk2d[noise_ids] = np.array([
+                noise_func[X_list[id]](kAP, muAP) if X_list[id]=='noise_k2mu2'
+                else noise_func[X_list[id]](kAP) for id in noise_ids])
+        multipoles = {}
+        for i,ell in enumerate(ells):
+            multipoles[f'ell{ell}'] = \
+                integrate.simps(Pk2d * legendre(ell, self.mu_grid),
+                                self.mu_grid, axis=-1)
             multipoles[f'ell{ell}'] *= (2.0 * prefactors[i])
         return multipoles
 

--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -273,14 +273,16 @@ class LegendreMultipoles:
             multipoles[f'ell{ell}'] *= (2.0 * prefactors[i])
         return multipoles
 
-    def power_X_multipoles(self, k: np.ndarray, X_list: list,
-                           ells: Optional[np.ndarray] = None,
-                           use_AP: Optional[bool] = True) -> dict:
+    def power_term_multipoles(self, k: np.ndarray, term_list: list,
+                              ells: Optional[np.ndarray] = None,
+                              use_AP: Optional[bool] = True) -> dict:
         r"""Power spectrum Legendre multipoles
         Parameters
         ----------
         k: np.ndarray
             Wavenumber
+        term_list: list
+            List of terms to compute
         ells: np.ndarray
             Legendre multipole order
         use_AP: bool
@@ -290,25 +292,28 @@ class LegendreMultipoles:
         multipoles: dict
             Power spectrum Legendre multipoles
         """
-        ells = self._ensure_array(ells) if ells is not None else np.array([0,2,4])
+        ells = self._ensure_array(ells) \
+            if ells is not None else np.array([0,2,4])
         AP_factor = (self._q_AP_tr(self.redshift)**2 *
                      self._q_AP_lo(self.redshift) if use_AP else 1.0)
         prefactors = np.array([(2.0 * m + 1.0) for m in ells]) / 2.0 / \
             AP_factor
-        Pk2d = np.empty((len(X_list), len(k), len(self.mu_grid)))
-        rsd_ids = [id for id, term in enumerate(X_list) if 'noise' not in term]
+        Pk2d = np.empty((len(term_list), len(k), len(self.mu_grid)))
+        rsd_ids = [id for id, term in enumerate(term_list)
+                   if 'noise' not in term]
         kAP = self._k_AP(k, self.mu_grid, self.redshift, use_AP=use_AP)
         muAP = self._mu_AP(self.mu_grid, self.redshift, use_AP=use_AP)
-        Pk2d[rsd_ids] = self.spectro_power.Pk2d_X_rsd(
-            kAP, muAP, X_list=[X_list[id] for id in rsd_ids])
-        noise_ids = [id for id in range(len(X_list)) if id not in rsd_ids]
+        Pk2d[rsd_ids] = self.spectro_power.Pk2d_term_rsd(
+            kAP, muAP, term_list=[term_list[id] for id in rsd_ids])
+        noise_ids = [id for id in range(len(term_list)) if id not in rsd_ids]
         noise_func = {'noise_k0': self._Pk2d_noise_k0,
                       'noise_k2': self._Pk2d_noise_k2,
                       'noise_k2mu2': self._Pk2d_noise_k2mu2}
         if noise_ids:
             Pk2d[noise_ids] = np.array([
-                noise_func[X_list[id]](kAP, muAP) if X_list[id]=='noise_k2mu2'
-                else noise_func[X_list[id]](kAP) for id in noise_ids])
+                noise_func[term_list[id]](kAP, muAP)
+                if term_list[id]=='noise_k2mu2'
+                else noise_func[term_list[id]](kAP) for id in noise_ids])
         multipoles = {}
         for i,ell in enumerate(ells):
             multipoles[f'ell{ell}'] = \

--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -299,21 +299,22 @@ class LegendreMultipoles:
         prefactors = np.array([(2.0 * m + 1.0) for m in ells]) / 2.0 / \
             AP_factor
         Pk2d = np.empty((len(term_list), len(k), len(self.mu_grid)))
-        rsd_ids = [id for id, term in enumerate(term_list)
+        rsd_ids = [index for index, term in enumerate(term_list)
                    if 'noise' not in term]
         kAP = self._k_AP(k, self.mu_grid, self.redshift, use_AP=use_AP)
         muAP = self._mu_AP(self.mu_grid, self.redshift, use_AP=use_AP)
         Pk2d[rsd_ids] = self.spectro_power.Pk2d_term_rsd(
-            kAP, muAP, term_list=[term_list[id] for id in rsd_ids])
-        noise_ids = [id for id in range(len(term_list)) if id not in rsd_ids]
+            kAP, muAP, term_list=[term_list[index] for index in rsd_ids])
+        noise_ids = [index for index in range(len(term_list))
+                     if index not in rsd_ids]
         noise_func = {'noise_k0': self._Pk2d_noise_k0,
                       'noise_k2': self._Pk2d_noise_k2,
                       'noise_k2mu2': self._Pk2d_noise_k2mu2}
         if noise_ids:
             Pk2d[noise_ids] = np.array([
-                noise_func[term_list[id]](kAP, muAP)
-                if term_list[id]=='noise_k2mu2'
-                else noise_func[term_list[id]](kAP) for id in noise_ids])
+                noise_func[term_list[index]](kAP, muAP)
+                if term_list[index]=='noise_k2mu2'
+                else noise_func[term_list[index]](kAP) for index in noise_ids])
         multipoles = {}
         for i,ell in enumerate(ells):
             multipoles[f'ell{ell}'] = \


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary
Added function power_X_multipoles to obtain the Legendre multipoles of a specific PT diagram (loop, counterterms, noise). Related to the noise terms, these have been defined individually and not with a single noise function, to allow for analytical marginalisation of any of these terms on their own. Also modified the interface functions in the comet spectro power classes (EFT and VDG) to accept a list of names for the specific diagrams different from the native ones of comet.

### 🔄 Changes
- [ ] Added power_X_multipoles function in legendre_multipoles.py (same structure of power_multipoles)
- [ ] Split 2d noise function into the separate contributions noise_k0, noise_k2, and noise_k2mu2
- [ ] Changed interface functions in the comet spectro power classes to adapt them to the naming convention of cloelib (the latter can be changed eventually)

### 📝 Documentation
- [ ] Added documentation for the new functions

### 🏗 Related Issues
Resolves #140
---

### ✅ PR Checklist for Developers
- [ ] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [ ] My code follows the repository's coding style
- [ ] I have tested my changes locally
- [ ] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [ ] My changes do not introduce breaking changes
- [ ] I have added tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers
- [x] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [x] Check that there are no `No newline at the end of file` warnings
- [x] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the implementation follows the contributing guidelines and style choices
- [x] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
