### PR TITLE
gh-51: implementation of photometric systematics

### DIFF
--- a/cloelib/auxiliary/math_utils.py
+++ b/cloelib/auxiliary/math_utils.py
@@ -49,8 +49,8 @@ _cached_stacked_simpson = {}
 
 def cached_stacked_simpson(n: int):
     key = str(n)
-    #TODO for the moment we are using a plain "if", later we are gonna need a lax conditional
-    #or a better cache mechanism
+    # TODO for the moment we are using a plain "if", later we are gonna need a lax conditional
+    # or a better cache mechanism
     if key not in _cached_stacked_simpson:
         _cached_stacked_simpson[key] = stacked_simpson(n)
     return _cached_stacked_simpson[key]
@@ -67,3 +67,12 @@ def legendre(n, x):
             Pn = ((2*k - 1) * x * P1 - (k - 1) * P0) / k
             P0, P1 = P1, Pn
         return Pn
+
+def simps(f, a, b, N=128):
+    if N % 2 == 1:
+        raise ValueError("N must be an even integer.")
+    dx = (b - a) / N
+    x = np.linspace(a, b, N + 1)
+    y = f(x)
+    S = dx / 3 * np.sum(y[0:-1:2] + 4 * y[1::2] + y[2::2], axis=0)
+    return S

--- a/cloelib/auxiliary/systematics.py
+++ b/cloelib/auxiliary/systematics.py
@@ -1,0 +1,42 @@
+import numpy as np
+import jax.numpy as jnp
+from jax import jit, lax
+from typing import Union, TypeVar
+
+T = TypeVar("T", bound=Union[jnp.ndarray, np.ndarray])
+
+@jit
+def shift_dndz_jax(dndz: T, z: T, dz: T) -> T:
+    """
+    Shift redshift distributions by a bin-specific offset using JAX-compatible interpolation.
+
+    This function interpolates each redshift distribution in `dndz` from a shifted redshift grid
+    `z - dz[i]` back onto the original `z` grid, allowing redshift bin shifts in auto-diff pipelines.
+
+    Parameters
+    ----------
+    dndz : Union[jnp.ndarray, np.ndarray]
+        Array of shape (N_bins, N_z), representing redshift distributions for each bin.
+    z : Union[jnp.ndarray, np.ndarray]
+        1D array of redshift values corresponding to the columns of `dndz`.
+    dz : Union[jnp.ndarray, np.ndarray]
+        1D array of length N_bins specifying redshift shift per bin.
+
+    Returns
+    -------
+    Union[jnp.ndarray, np.ndarray]
+        Shifted redshift distributions, same shape as `dndz`, interpolated and zero-padded where needed.
+
+    Notes
+    -----
+    - Interpolation outside bounds is filled with zero.
+    - Assumes input `dndz` is already normalized.
+    - JAX-compatible and JIT-compiled for use in differentiable models.
+    """
+    def interp_single_bin(i):
+        z_shifted = z - dz[i]
+        return jnp.interp(z, z_shifted, dndz[i], left=0.0, right=0.0)
+
+    bins = dndz.shape[0]
+    shifted = jnp.stack([interp_single_bin(i) for i in range(bins)], axis=0)
+    return shifted

--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -51,6 +51,8 @@ class ShearTracer:
         self.nuisance_params = nuisance_params
         # This is to add the necessary prefactor to shear, while avoiding it in GC
         self.prefact_toggle = 1
+        # Set multiplicative bias (m_bias)
+        self.m_bias = [self.nuisance_params[f'multiplicative_bias_{i+1}'] for i in range(self.dndz.shape[0])]
 
     def get_window_IA(self, z):
         r"""Window integrand.
@@ -78,13 +80,9 @@ class ShearTracer:
 
     def get_lensing_efficiency_bin(self, z, bin_idx):
         interpolator = interpax.Akima1DInterpolator(self.z, self.dndz[bin_idx,:])
-        #horrible quick fix
-        #to make it right, we need the triangular matrix of simpson weight for the
-        #lensing efficiency. This will also significantly improve performance!
         x = np.linspace(0., 4, 200)
         y = self.background.comoving_distance(x)
         rx_interp = interpax.Akima1DInterpolator(x, y)
-        #f1 = lambda x, y: interpolator(x)*(1-tracer_she.background.comoving_distance(y)/tracer_she.background.comoving_distance(x))
         f1 = jax.jit(lambda x: interpolator(x))
         f2 = jax.jit(lambda x: interpolator(x)/rx_interp(x))
         integral_1 =  simps(f1, z, 3.)
@@ -97,12 +95,11 @@ class ShearTracer:
         efficiency = self.get_lensing_efficiency_bin(z, 0)
         for i in np.arange(1,n_bins):
             efficiency = np.vstack([efficiency, self.get_lensing_efficiency_bin(z, i)])
-
         return efficiency
 
     def get_lensing_efficiency(self, z):
         dndz = self.dndz
-        dz = z[1]-z[0]#assuming equispaced!
+        dz = z[1]-z[0] # assuming equispaced!
         rz = self.background.comoving_distance(z)
         rzrz = 1 - np.outer(rz,1/rz)
         w_matrix = cached_stacked_simpson(len(z))
@@ -185,7 +182,10 @@ class ShearTracer:
         -------
         window: np.ndarray
         """
-        return self.get_lensing_window(z) + self.get_window_IA(z)
+        total_window = self.get_lensing_window(z) + self.get_window_IA(z)
+        # Apply multiplicative bias
+        total_window *= (1 + np.array(self.m_bias)[:, None])
+        return total_window
 
 class PositionsTracer:
     def __init__(self, perturbations: Perturbations, dndz: np.ndarray, z: np.ndarray,

--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -1,7 +1,8 @@
 # cloelib imports
 from cloelib.auxiliary.units import SPEED_OF_LIGHT
 from cloelib.cosmology.cosmology import Perturbations
-from cloelib.auxiliary.math_utils import cached_stacked_simpson
+from cloelib.auxiliary.math_utils import cached_stacked_simpson, simps
+from cloelib.auxiliary.systematics import shift_dndz_jax
 
 # General imports
 import jax.numpy as np # type: ignore
@@ -15,8 +16,8 @@ import jax.lax as lx
 
 ## Notes:
 
-- Make sufficiently general to interface with CAMB keeping the structure by Cosmology
-- Make Tracer a protocol
+- Define a class for each observable tracer type: shear and galaxy positions
+- Both classes are compatible with the Tracer protocol
 
 """
 
@@ -46,13 +47,17 @@ class ShearTracer:
             raise ValueError("One of the z array elements is equal to zero, breaking Limber integration.")
         self.perturbations = perturbations
         self.background = self.perturbations.background
-        self.dndz = dndz
         self.z = z
         self.nuisance_params = nuisance_params
         # This is to add the necessary prefactor to shear, while avoiding it in GC
         self.prefact_toggle = 1
         # Set multiplicative bias (m_bias)
-        self.m_bias = [self.nuisance_params[f'multiplicative_bias_{i+1}'] for i in range(self.dndz.shape[0])]
+        self.m_bias = [self.nuisance_params[f'multiplicative_bias_{i+1}'] for i in range(dndz.shape[0])]
+        self.dz_shear_i = [self.nuisance_params[f'dz_shear_{i+1}'] for i in range(dndz.shape[0])]
+        self.n_z_bins = dndz.shape[0]
+        self.dndz = dndz
+        # Correct dndz for dz_shear
+        self.dndz_shifted = shift_dndz_jax(dndz, z, self.dz_shear_i)
 
     def get_window_IA(self, z):
         r"""Window integrand.
@@ -90,14 +95,32 @@ class ShearTracer:
         efficiency = integral_1 - integral_2*self.background.comoving_distance(z)
         return efficiency
 
-    def get_lensing_efficiency_check(self, z):
-        n_bins = self.dndz.shape[0]
-        efficiency = self.get_lensing_efficiency_bin(z, 0)
-        for i in np.arange(1,n_bins):
-            efficiency = np.vstack([efficiency, self.get_lensing_efficiency_bin(z, i)])
-        return efficiency
-
     def get_lensing_efficiency(self, z):
+        r"""
+        Compute the lensing efficiency kernel for each redshift bin.
+
+        This function calculates the geometric lensing kernel W(χ), which weights the contribution
+        of matter at different redshifts to the weak lensing signal, for a given redshift grid `z`.
+
+        Parameters
+        ----------
+        z : np.ndarray
+            1D array of redshift values (must be evenly spaced). Used to compute comoving distances
+            and define integration domain.
+
+        Returns
+        -------
+        np.ndarray
+            2D array of shape (N_bins, len(z)) representing the lensing efficiency kernel W(z) 
+            for each redshift bin over the evaluation grid.
+
+        Notes
+        -----
+        - Assumes `z` is evenly spaced; spacing is inferred as `z[1] - z[0]`.
+        - Uses a precomputed Simpson rule weight matrix (`cached_stacked_simpson`) for integration.
+        - `self.dndz` is expected to have shape (N_bins, len(z)) and be normalized.
+        - Efficiency is evaluated using `np.einsum`.
+        """
         dndz = self.dndz
         dz = z[1]-z[0] # assuming equispaced!
         rz = self.background.comoving_distance(z)
@@ -105,12 +128,6 @@ class ShearTracer:
         w_matrix = cached_stacked_simpson(len(z))
         result = np.einsum('ik, jk, jk->ij', dndz, rzrz, w_matrix)*dz
         return result
-
-    def get_lensing_window_check(self, z):
-        factor = 3/2*(self.background.H0/c_0)**2*(self.background.Omega_b0 + self.background.Omega_cdm0)\
-        *(1+z)*self.background.comoving_distance(z)
-        efficiency = self.get_lensing_efficiency_check(z)
-        return np.einsum('ij, j->ij', efficiency, factor)
 
     def get_lensing_window(self, z):
         r"""Weak Lensing shear kernel.
@@ -151,22 +168,6 @@ class ShearTracer:
         *(1+z)*self.background.comoving_distance(z)
         efficiency = self.get_lensing_efficiency(z)
         return np.einsum('ij, j->ij', efficiency, factor)
-
-    def get_window_check(self, z):
-        r"""Window
-
-        Computes general window given the selected tracer
-
-        Parameters
-        ----------
-        z: float
-            Redshift at which window kernel is being evaluated
-
-        Returns
-        -------
-        window: np.ndarray
-        """
-        return self.get_lensing_window_check(z) + self.get_window_IA(z)
 
     def get_window(self, z):
         r"""Window
@@ -213,14 +214,16 @@ class PositionsTracer:
         if 0. in z:
             raise ValueError("One of the z array elements is equal to zero, breaking Limber integration.")
         self.perturbations = perturbations
-        self.dndz = dndz
         self.z = z
         # This is to add the necessary prefactor to shear, while avoiding it in GC
         self.prefact_toggle = 0
 
         self.nuisance_params = nuisance_params
+        self.dz_pos_i = [self.nuisance_params[f'dz_pos_{i+1}'] for i in range(dndz.shape[0])]
+        self.dndz = dndz
+        # Correct dndz for dz_pos
+        self.dndz_shifted = shift_dndz_jax(dndz, z, self.dz_pos_i)
         self.flags = {'galaxy_bias_model': galaxy_bias_model}
-
         self.n_z_bins = dndz.shape[0]
 
         # Using dict.get so I can provide a default since lax has to compile every branch of the conditional
@@ -300,13 +303,3 @@ class PositionsTracer:
         """
         # add more contributions below
         return self.get_window_positions(z)
-
-
-def simps(f, a, b, N=128):
-    if N % 2 == 1:
-        raise ValueError("N must be an even integer.")
-    dx = (b - a) / N
-    x = np.linspace(a, b, N + 1)
-    y = f(x)
-    S = dx / 3 * np.sum(y[0:-1:2] + 4 * y[1::2] + y[2::2], axis=0)
-    return S

--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -150,12 +150,6 @@ class ShearTracer:
         ----------
         z: numpy.ndarray of float
             Redshift at which weight is evaluated.
-        bin_i: int
-            Index of desired tomographic bin.
-            Tomographic bin indices start from 1
-        k: float
-            Wavenumber at which to evaluate the Modified Gravity
-            :math:`\Sigma(z,k)` function
 
         Returns
         -------

--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -129,7 +129,7 @@ class ShearTracer:
         result = np.einsum('ik, jk, jk->ij', dndz, rzrz, w_matrix)*dz
         return result
 
-    def get_lensing_window(self, z):
+    def get_window_lensing(self, z):
         r"""Weak Lensing shear kernel.
 
         Calculates the weak lensing shear kernel for a given tomographic bin
@@ -140,7 +140,7 @@ class ShearTracer:
         .. math::
             W_{i}^{\gamma}(\ell, z, k) =
             \frac{3}{2}\left ( \frac{H_0}{c}\right )^2
-            \Omega_{{\rm m},0} (1 + z) \Sigma(z, k)
+            \Omega_{{\rm m},0} (1 + z)
             f_K\left[\tilde{r}(z)\right]
             \int_{z}^{z_{\rm max}}{{\rm d}z^{\prime} n_{i}^{\rm L}(z^{\prime})
             \frac{f_K\left[\tilde{r}(z^{\prime}) - \tilde{r}(z)\right]}
@@ -183,7 +183,7 @@ class ShearTracer:
         -------
         window: np.ndarray
         """
-        total_window = self.get_lensing_window(z) + self.get_window_IA(z)
+        total_window = self.get_window_lensing(z) + self.get_window_IA(z)
         # Apply multiplicative bias
         total_window *= (1 + np.array(self.m_bias)[:, None])
         return total_window
@@ -214,6 +214,7 @@ class PositionsTracer:
         if 0. in z:
             raise ValueError("One of the z array elements is equal to zero, breaking Limber integration.")
         self.perturbations = perturbations
+        self.background = self.perturbations.background
         self.z = z
         # This is to add the necessary prefactor to shear, while avoiding it in GC
         self.prefact_toggle = 0
@@ -225,6 +226,7 @@ class PositionsTracer:
         self.dndz_shifted = shift_dndz_jax(dndz, z, self.dz_pos_i)
         self.flags = {'galaxy_bias_model': galaxy_bias_model}
         self.n_z_bins = dndz.shape[0]
+        self.magnification_bias = [self.nuisance_params[f'magnification_bias_{i+1}'] for i in range(dndz.shape[0])]
 
         # Using dict.get so I can provide a default since lax has to compile every branch of the conditional
         def per_bin_case():
@@ -288,9 +290,88 @@ class PositionsTracer:
 
         return window_positions
 
+    def get_magnification_efficiency(self, z):
+        r"""
+        Compute the magnification efficiency kernel for each redshift bin.
+
+        This function calculates the geometric lensing kernel W(χ), which weights the contribution
+        of matter at different redshifts to the weak lensing signal, for a given redshift grid `z`.
+
+        Parameters
+        ----------
+        z : np.ndarray
+            1D array of redshift values (must be evenly spaced). Used to compute comoving distances
+            and define integration domain.
+
+        Returns
+        -------
+        np.ndarray
+            2D array of shape (N_bins, len(z)) representing the lensing efficiency kernel W(z) 
+            for each redshift bin over the evaluation grid.
+
+        Notes
+        -----
+        - Assumes `z` is evenly spaced; spacing is inferred as `z[1] - z[0]`.
+        - Uses a precomputed Simpson rule weight matrix (`cached_stacked_simpson`) for integration.
+        - `self.dndz` is expected to have shape (N_bins, len(z)) and be normalized.
+        - Efficiency is evaluated using `np.einsum`.
+        """
+        dndz = self.dndz
+        dz = z[1]-z[0] # assuming equispaced!
+        rz = self.background.comoving_distance(z)
+        rzrz = 1 - np.outer(rz,1/rz)
+        w_matrix = cached_stacked_simpson(len(z))
+        result = np.einsum('ik, jk, jk->ij', dndz, rzrz, w_matrix)*dz
+        return result
+
+    def get_magnification_window(self, z):
+        r"""Magnification photometric galaxy kernel.
+
+        Calculates the weak lensing shear kernel for a given tomographic bin
+        distribution.
+        Uses broadcasting to compute a 2D-array of integrands and then applies
+        :obj:`np.trapz` on the array along one axis.
+
+        .. math::
+            W_{i}^{\gamma}(\ell, z, k) =
+            \frac{3}{2}\left ( \frac{H_0}{c}\right )^2
+            \Omega_{{\rm m},0} b_{\rm mag, i} (1 + z)
+            f_K\left[\tilde{r}(z)\right]
+            \int_{z}^{z_{\rm max}}{{\rm d}z^{\prime} n_{i}^{\rm L}(z^{\prime})
+            \frac{f_K\left[\tilde{r}(z^{\prime}) - \tilde{r}(z)\right]}
+            {f_K\left[\tilde{r}(z^{\prime})\right]}}\\
+
+        Parameters
+        ----------
+        z: numpy.ndarray of float
+            Redshift at which weight is evaluated.
+        bin_i: int
+            Index of desired tomographic bin.
+            Tomographic bin indices start from 1
+        k: float
+            Wavenumber at which to evaluate the Modified Gravity
+            :math:`\Sigma(z,k)` function
+
+        Returns
+        -------
+        Shear kernel: numpy.ndarray
+            1-D Numpy array of shear kernel values for specified bin
+            at specified scale for the redshifts defined in z
+        """
+        Omega_m0 = self.background.Omega_m(0.0)
+        factor = 3/2*(self.background.H0/c_0)**2*Omega_m0\
+        *(1+z)\
+            *self.background.comoving_distance(z)
+        efficiency = self.get_magnification_efficiency(z)
+        return np.einsum('ij, j->ij', efficiency, factor)*np.array(self.magnification_bias)[:, None]
+
     def get_window(self, z) -> np.ndarray:
         """
         Computes the angular photometric galaxy clustering window function.
+
+        If magnification bias is zero, it computes the window function
+        using the galaxy positions. Otherwise, it computes the window function
+        using both the galaxy positions and the magnification bias.
 
         Parameters
         ----------
@@ -301,5 +382,19 @@ class PositionsTracer:
         -------
         window: np.ndarray
         """
-        # add more contributions below
-        return self.get_window_positions(z)
+        def calculate_with_magnification():
+            return self.get_window_positions(z) + self.get_magnification_window(z)
+
+        def calculate_without_magnification():
+            return self.get_window_positions(z)
+
+        # Check if all terms in self.magnification_bias are zero
+        is_magnification_zero = jax.numpy.all(jax.numpy.array(self.magnification_bias) == 0.0)
+
+        # Use lax.cond to handle the conditional logic
+        window = lx.cond(
+            is_magnification_zero,
+            calculate_without_magnification,
+            calculate_with_magnification)
+
+        return window 


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary
Implementation of photometric systematic nuisance parameters as in former CLOE v2.0.2: multiplicative bias and redshift bin mean shifts.
Also included magnification bias for photometric angular clustering, but only the case of one bias per redshift bin.

New systematic nuisance parameters are passed in the initialisation of `Tracer`, within the `nuisance_params` dictionary. They are named `multiplicative_bias_i`,  `dz_shear/pos_i`,  and `magnification_bias_i`, respectively. 

### 🔄 Changes
<!-- List the major changes in this PR. Bullet points preferred. -->
- [x] Implementation of the multiplicative bias in the `ShearTracer` at the level of `get_window` function
- [ ] Implementaon of the magnification bias in the `PositionsTracer`, including analogous functions as in the lensing efficiency case
- [x] Implementation of the shift in the redshift bin mean for both `ShearTracer` and `PositionTracer` at the `__init__` level: the new _shifted_ `dndz` are saved as attributes of the classes (the method to shift the distributions is in a new `systematics.py` file within `auxiliary`, and it is `JAX` compatible)

### 🛠 How to Test
<!-- Provide steps to test the changes. Include commands if applicable. -->
- `photo.ipynb` in playground is updated accordantly (https://github.com/cloe-org/playground/pull/25)

### 📝 Documentation
- [x] This PR updates documentation
- [ ] This PR does not require documentation changes
- [ ] Issue created for documentation update: Don't forget to link the task!

### 🏗 Related Issues
Resolves #51 and #50 and #31

### 📸 Screenshots (if applicable)
<!-- Upload screenshots to show scientific plots or other graphics -->
Example of the shifted dndz.

![shift_example](https://github.com/user-attachments/assets/4a497958-6641-4cc7-9df9-0802dad5331b)


### 📌 Additional Notes
- Cleaned `photo.py` removing deprecated check functions
- Added docs and comments to functions in `photo.py`

---

### ✅ PR Checklist for Developers
- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] My code follows the repository's coding style
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [x] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes
- [ ] I have added tests (if applicable)
- [x] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers
- [ ] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [ ] Check that there are no `No newline at the end of file` warnings
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the implementation follows the contributing guidelines and style choices
- [ ] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
