### PR TITLE
gh-157: normalization of nz after shift

### DIFF
--- a/cloelib/auxiliary/systematics.py
+++ b/cloelib/auxiliary/systematics.py
@@ -39,4 +39,5 @@ def shift_dndz_jax(dndz: T, z: T, dz: T) -> T:
 
     bins = dndz.shape[0]
     shifted = jnp.stack([interp_single_bin(i) for i in range(bins)], axis=0)
-    return shifted
+    normalization = (-0.5*(shifted[0]+shifted[-1])+jnp.sum(shifted))*(z[1]-z[0])
+    return shifted*normalization

--- a/cloelib/auxiliary/systematics.py
+++ b/cloelib/auxiliary/systematics.py
@@ -40,4 +40,4 @@ def shift_dndz_jax(dndz: T, z: T, dz: T) -> T:
     bins = dndz.shape[0]
     shifted = jnp.stack([interp_single_bin(i) for i in range(bins)], axis=0)
     normalization = (-0.5*(shifted[0]+shifted[-1])+jnp.sum(shifted))*(z[1]-z[0])
-    return shifted*normalization
+    return shifted/normalization

--- a/cloelib/auxiliary/systematics.py
+++ b/cloelib/auxiliary/systematics.py
@@ -39,5 +39,6 @@ def shift_dndz_jax(dndz: T, z: T, dz: T) -> T:
 
     bins = dndz.shape[0]
     shifted = jnp.stack([interp_single_bin(i) for i in range(bins)], axis=0)
+    #do the cumulative trapezoidal integral (notice the different treatment of first and last point)
     normalization = (-0.5*(shifted[0]+shifted[-1])+jnp.sum(shifted))*(z[1]-z[0])
     return shifted/normalization

--- a/cloelib/auxiliary/systematics.py
+++ b/cloelib/auxiliary/systematics.py
@@ -30,7 +30,7 @@ def shift_dndz_jax(dndz: T, z: T, dz: T) -> T:
     Notes
     -----
     - Interpolation outside bounds is filled with zero.
-    - Assumes input `dndz` is already normalized.
+    - `dndz` is being normalized _by this function_ .
     - JAX-compatible and JIT-compiled for use in differentiable models.
     """
     def interp_single_bin(i):


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary
Previously we were assuming the dndz being normalized. However, once we introduce the shifts, this is not true anymore.

### 🔄 Changes
<!-- List the major changes in this PR. Bullet points preferred. -->
- [ ] Enforced normalization when shifting the $n(z)$ distributions

### 🛠 How to Test
Provide a $n(z)$ normalized to different values (1, 2, 3, ...).
Check that the resulting dndz after shift is almost the same.

### 📝 Documentation
- [ ] This PR updates documentation

### 🏗 Related Issues
Resolves #157 

---

### ✅ PR Checklist for Developers
- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] My code follows the repository's coding style
- [ ] I have tested my changes locally
- [ ] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes
- [ ] I have added tests (if applicable)
- [x] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers
- [x] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [x] Check that there are no `No newline at the end of file` warnings
- [x] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the implementation follows the contributing guidelines and style choices
- [x] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
