### PR TITLE
gh-205: Change CAMB dark energy model from default fluid to ppf

### DIFF
--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -57,7 +57,8 @@ class CAMBBackground:
             omk=self.Omega_k0,
             mnu = self.mnu
         )
-        self.interface_args['CAMBparams'].set_dark_energy(w=self.w0, wa=self.wa)
+        self.interface_args['CAMBparams'].set_dark_energy(w=self.w0, wa=self.wa,
+                                                          dark_energy_model='ppf')
         self.interface_args['CAMBparams'].InitPower.set_params(As=self.As, ns=self.ns)
 
         # Call CAMB to compute the background


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary
Change the dark energy model from fluid to ppf in CAMB

### 🔄 Changes
- [ ] add the argument dark_energy_model='ppf' to .set_dark_energy in camb_cosmology.py

### 🛠 How to Test
Run cloelib with values of w0 and wa that result in phantom crossing and it works.

### 📝 Documentation
- [ ] This PR updates documentation
- [x] This PR does not require documentation changes
- [ ] Issue created for documentation update: Don't forget to link the task!

### 🏗 Related Issues
<!-- Link related issues. Use closing keywords if applicable. -->
Resolves issue #205 

---

### ✅ PR Checklist for Developers
- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] My code follows the repository's coding style
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes
- [ ] I have added tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers
- [x] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [x] Check that there are no `No newline at the end of file` warnings
- [ ] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the implementation follows the contributing guidelines and style choices
- [ ] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it
