### PR TITLE
gh-216: Add log10_TAGN

### DIFF
--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -295,7 +295,9 @@ class CAMBNonLinearPerturbations:
         self.background.interface_args['CAMBparams'].WantTransfer = True
         
         if nonlinear_model is not None:
-            self.background.interface_args['CAMBparams'].NonLinearModel.set_params(halofit_version=nonlinear_model, HMCode_logT_AGN=log10TAGN)
+            self.background.interface_args['CAMBparams'].NonLinearModel.set_params(halofit_version=nonlinear_model)
+            if log10TAGN is not None:
+                self.background.interface_args['CAMBparams'].NonLinearModel.set_params(halofit_version=nonlinear_model, HMCode_logT_AGN=log10TAGN)
         else:
             self.background.interface_args['CAMBparams'].NonLinearModel.set_params()
 

--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -269,7 +269,7 @@ class CAMBNonLinearPerturbations:
     """A wrapper for CAMB nonlinear perturbation calculations."""
 
     def __init__(self, background: Background, redshifts: np.ndarray,
-                 nonlinear_model: Optional[str] = None, log10TAGN: float = None) -> None:
+                 nonlinear_model: Optional[str] = None, log10TAGN: Optional[float] = None) -> None:
         """
         Initialize the CAMBNonLinearPerturbations class with linear perturbation data.
 

--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -49,7 +49,7 @@ class CAMBBackground:
         self.mnu = mnu
 
         # Initialize CAMB parameters
-        self.interface_args = {'CAMBparams': camb.CAMBparams()}
+        self.interface_args = {'CAMBparams': camb.CAMBparams()}  
         self.interface_args['CAMBparams'].set_cosmology(
             H0=self.H0,
             ombh2=self.Omega_b0 * (self.h) ** 2,
@@ -269,7 +269,7 @@ class CAMBNonLinearPerturbations:
     """A wrapper for CAMB nonlinear perturbation calculations."""
 
     def __init__(self, background: Background, redshifts: np.ndarray,
-                 nonlinear_model: Optional[str] = None) -> None:
+                 nonlinear_model: Optional[str] = None, log10TAGN: float = None) -> None:
         """
         Initialize the CAMBNonLinearPerturbations class with linear perturbation data.
 
@@ -294,8 +294,10 @@ class CAMBNonLinearPerturbations:
         self.background.interface_args['CAMBparams'].Want_cl_2D_array = False
         self.background.interface_args['CAMBparams'].WantTransfer = True
         
-        if nonlinear_model:
-            self.background.interface_args['CAMBparams'].NonLinearModel.set_params(halofit_version=nonlinear_model)
+        if nonlinear_model is not None:
+            self.background.interface_args['CAMBparams'].NonLinearModel.set_params(halofit_version=nonlinear_model, HMCode_logT_AGN=log10TAGN)
+        else:
+            self.background.interface_args['CAMBparams'].NonLinearModel.set_params()
 
         self.background.interface_args['CAMBparams'].set_matter_power(redshifts=redshifts, kmax=self.kmax)
 


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary
I have added the log10_TAGN parameter to CAMBNonLinearPerturbations, which allows for varying the log10_TAGN parameter that accounts for baryonic feedback. 

### 🔄 Changes
<!-- List the major changes in this PR. Bullet points preferred. -->
- [ ] added log10_TAGN parameter to CAMBNonLinearPerturbations
- [ ] If no nonlinear_model is given, it uses the default.

### 🛠 How to Test
Specify in CAMBNonLinearPerturbations nonlinear_model = 'mead2020_feedback' and log10TAGN and the matter power spectrum will change.


### 🏗 Related Issues
<!-- Link related issues. Use closing keywords if applicable. -->
Resolves #216
Fixes #216

### ✅ PR Checklist for Developers
- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] My code follows the repository's coding style
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [x] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes
- [x] I have added tests (if applicable)
- [x] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers
- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [x] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [x] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [x] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [x] Check that there are no `No newline at the end of file` warnings
- [x] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the implementation follows the contributing guidelines and style choices
- [x] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it



