### PR TITLE
gh-244: rdrag in bao obtained from background

### DIFF
--- a/cloelib/summary_statistics/bao_alphas.py
+++ b/cloelib/summary_statistics/bao_alphas.py
@@ -38,9 +38,7 @@ class BaryonAcousticOscillations:
         self.background_fiducial = background_fiducial
         self.zs = redshifts
         self.Neff = 3.046  # This is hardcoded but should come from background
-        self.rd_ratio = self.sound_horizon_drag(
-            self.background_fiducial
-        ) / self.sound_horizon_drag(self.background)
+        self.rd_ratio = self.background_fiducial.rdrag / self.background.rdrag
         self.ap_distortion = APDistortion(background, background_fiducial)
 
         # the `alphas_dict` attribute is a dictionary containing
@@ -155,30 +153,3 @@ class BaryonAcousticOscillations:
             for i, z in enumerate(self.zs)
         }
         return alphas
-
-    def sound_horizon_drag(self, background):
-        r"""Compute the sound horizon at drag epoch.
-
-        Uses the fitting formula Eq.17
-        of [1411.1074](https://arxiv.org/abs/1411.1074)
-
-        Parameters
-        ----------
-        background: Background
-            Background class containing cosmology
-
-        Returns
-        -------
-        r_d: float
-            Sound horizon at drag epoch
-        """
-        omega_cb = background.Omega_cdm0 * background.h**2
-        omega_b = background.Omega_b0 * background.h**2
-        omega_nu = background.mnu * 93.14
-
-        r_d = (
-            56.067
-            * np.exp(-49.7 * (omega_nu + 0.002) ** 2)
-            / (omega_cb**0.2436 * omega_b**0.128876 * (1 + (self.Neff - 3.046) / 30.6))
-        )
-        return r_d


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

The BAO module has an had hoc implementation of the sound horizon drag, using a fitting function, that should have been removed when it `rdrag` became a property of the Background protocol.

### 🔄 Changes

- removed `sound_horizon_drag` from `bao_alphas.py`
- `rd_ratio` now derived from instances of `Background`


### 🛠 How to Test

Run bao notebook in playground, `alphas_dict` contains almost identical values. The difference comes from the fact that now r_drag is obtained from camb rather than from the fitting function

### 📝 Documentation

- [ ] This PR updates documentation
- [x] This PR does not require documentation changes
- [ ] Issue created for documentation update: Don't forget to link the task!

### 🏗 Related Issues

Closes #244 

---

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [ ] I have added unit tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [ ] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [ ] Check that there are no `No newline at the end of file` warnings
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the implementation follows the contributing guidelines and style choices
- [ ] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
