### PR TITLE
gh-356: np.arange fix, now to n+1

### DIFF
--- a/cloelib/auxiliary/cosebi_helpers.py
+++ b/cloelib/auxiliary/cosebi_helpers.py
@@ -249,7 +249,7 @@ def get_W_ell(thetagrid, Nmax, ells, N_thread):
 
     rn, nn, coeff_j = get_roots_and_norms(tmax, tmin, Nmax)
     print("done")
-    ns = np.arange(1, Nmax)
+    ns = np.arange(1, Nmax + 1)
     w_ells = {}
 
     print("start performing the bessel integrals")


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

COSEBIS range from 1 to Nmax, hence the correct indexing is np.arange(1,Nmax +1), the previous version had np.arange(1, Nmax), currently all works fine if you use Nmax = Nmax + 1, but this can easily lead to errors. 

### 🔄 Changes

See above