### PR TITLE
gh-365: swap ggl indices

### DIFF
--- a/cloelib/summary_statistics/angular_two_point.py
+++ b/cloelib/summary_statistics/angular_two_point.py
@@ -194,7 +194,7 @@ class AngularTwoPoint:
 
             return {
                 ("POS", "SHE", i, j): np.stack([block1, np.zeros_like(block1)]),
-                ("POS", "SHE", i, j): np.stack([block2, np.zeros_like(block2)]),
+                ("POS", "SHE", j, i): np.stack([block2, np.zeros_like(block2)]),
             }
 
         def she_she_rule(C, i, j):

--- a/cloelib/summary_statistics/angular_two_point.py
+++ b/cloelib/summary_statistics/angular_two_point.py
@@ -193,7 +193,7 @@ class AngularTwoPoint:
             block2 = C[:, j - 1, i - 1]
 
             return {
-                ("POS", "SHE", j, i): np.stack([block1, np.zeros_like(block1)]),
+                ("POS", "SHE", i, j): np.stack([block1, np.zeros_like(block1)]),
                 ("POS", "SHE", i, j): np.stack([block2, np.zeros_like(block2)]),
             }
 


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

GGL redshift bin indices were swapped in pos_she_rule function of angular_two_point.py.  The indices in the key do not match the ones used in the blocks.

### 🔄 Changes
- i,j order for block one and j,i for block two


### 🛠 How to Test
- Compare with Heracles 

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [ ] I have added unit tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [x] Check that there are no `No newline at the end of file` warnings
- [x] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the implementation follows the contributing guidelines and style choices
- [x] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it
