### PR TITLE
gh-414: Fixing redshift variable used when computing growth factor in IA window

### DIFF
--- a/cloelib/observables/photo.py
+++ b/cloelib/observables/photo.py
@@ -76,9 +76,7 @@ class ShearTracer:
         """
         Omega_m0 = self.background.Omega_m(0.0)
         Hz = self.perturbations.background.hubble_parameter(z)
-        Dz = self.perturbations.growth_factor(
-            self.perturbations.z, self.perturbations.k
-        )[:, 1]
+        Dz = self.perturbations.growth_factor(z, self.perturbations.k)[:, 1]
         # TODO discuss whether we want growth factor to output a 1D or a 2D array
         A_IA = self.nuisance_params["AIA"]
         C_IA = self.nuisance_params["CIA"]


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

This PR fixes the redshift variable being used when computing the growth factor in the IA window function, as discussed in issue #414. 

### 🏗 Related Issues

Resolves #414 

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [ ] I have added unit tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [x] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [x] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [x] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [ ] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it
