### PR TITLE
gh-476 : fixing CAMB and CLASS NonLinearPerturbations interface issue

### DIFF
--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -446,6 +446,7 @@ class CAMBNonLinearPerturbations:
     def __init__(
         self,
         background: Background,
+        linearperturbations,
         redshifts: np.ndarray,
         nonlinear_model: Optional[str] = None,
         log10TAGN: Optional[float] = None,
@@ -455,6 +456,9 @@ class CAMBNonLinearPerturbations:
 
         Args:
             self (LinearPerturbations): An instance of the LinearPerturbations class.
+            linearperturbations: Linear perturbations object (unused by CAMB, which computes
+                nonlinear corrections internally; accepted for interface compatibility with
+                emulator-based NonLinPerturbations classes).
             redshifts (np.ndarray): Array of redshifts for the calculations.
             nonlinear_model (Optional[str]): The nonlinear model to use (e.g., "takahashi").
                 Defaults to None, which uses the CAMB default model.

--- a/cloelib/cosmology/camb_cosmology.py
+++ b/cloelib/cosmology/camb_cosmology.py
@@ -446,7 +446,7 @@ class CAMBNonLinearPerturbations:
     def __init__(
         self,
         background: Background,
-        linearperturbations,
+        linearperturbations: Optional[object],
         redshifts: np.ndarray,
         nonlinear_model: Optional[str] = None,
         log10TAGN: Optional[float] = None,

--- a/cloelib/cosmology/class_cosmology.py
+++ b/cloelib/cosmology/class_cosmology.py
@@ -436,11 +436,22 @@ class CLASSNonLinearPerturbations:
     def __init__(
         self,
         background: Background,
+        linearperturbations: Optional[object],
         redshifts: np.ndarray,
         nonlinear_model: Optional[str] = None,
         hmcode_version: Optional[str] = None,
     ):
-        """Initialize the CLASSNonLinearPerturbation instance."""
+        """Initialize the CLASSNonLinearPerturbation instance.
+
+        Args:
+            background: Background cosmology object.
+            linearperturbations: Linear perturbations object (unused by CLASS, which computes
+                nonlinear corrections internally; accepted for interface compatibility with
+                emulator-based NonLinPerturbations classes).
+            redshifts (np.ndarray): Array of redshifts for the calculations.
+            nonlinear_model (Optional[str]): The nonlinear model to use. Defaults to None (no nonlinear).
+            hmcode_version (Optional[str]): The HMcode version to use. Defaults to None.
+        """
         self.background = background
         self.z = redshifts
         self.kmax = 100

--- a/docs/code_structure/perturbations.md
+++ b/docs/code_structure/perturbations.md
@@ -228,6 +228,8 @@ class MySolverPerturbations:
     def __init__(
         self,
         background: Background,
+        linearperturbations: Optional[object] = None,
+        redshifts: np.ndarray = None,
         nonlinear_model: str = "halofit",
         kmax: float = 10.0,
         zmax: float = 5.0,
@@ -238,6 +240,11 @@ class MySolverPerturbations:
 
         Args:
             background: Background object (any implementation)
+            linearperturbations: Linear perturbations object. Accepted for interface
+                compatibility with cloelike, which always passes this as the second
+                positional argument when constructing NonLinPerturbations. Unused by
+                codes that compute nonlinear corrections internally (e.g. CAMB, CLASS).
+            redshifts: Array of redshifts for the calculations.
             nonlinear_model: Which non-linear model to use
             kmax: Maximum wavenumber in 1/Mpc
             zmax: Maximum redshift

--- a/tests/test_camb_cosmology.py
+++ b/tests/test_camb_cosmology.py
@@ -339,7 +339,10 @@ def camb_perturbation_instances(camb_background_instance, zs, scope="module"):
         background=camb_background_instance, redshifts=zs
     )
     camb_non = CAMBNonLinearPerturbations(
-        background=camb_background_instance, redshifts=zs, nonlinear_model="mead2016"
+        background=camb_background_instance,
+        linearperturbations=None,
+        redshifts=zs,
+        nonlinear_model="mead2016",
     )
     return {"Linear": camb_lin, "NonLinear": camb_non}
 
@@ -416,7 +419,7 @@ def test_camb_nonlinear_perturbations_z_zero_automatic_inclusion(
     user_redshifts = np.array([0.5, 1.0, 1.5, 2.0])
 
     nonlinear_pert = CAMBNonLinearPerturbations(
-        camb_background_instance, user_redshifts, nonlinear_model="mead2016"
+        camb_background_instance, None, user_redshifts, nonlinear_model="mead2016"
     )
 
     # Check that z=0 was automatically added to internal array
@@ -449,7 +452,7 @@ def test_camb_sigma8_consistency_linear_vs_nonlinear(camb_background_instance):
 
     linear_pert = CAMBLinearPerturbations(camb_background_instance, user_redshifts)
     nonlinear_pert = CAMBNonLinearPerturbations(
-        camb_background_instance, user_redshifts, nonlinear_model="mead2016"
+        camb_background_instance, None, user_redshifts, nonlinear_model="mead2016"
     )
 
     # Both should compute sigma8_0
@@ -485,7 +488,7 @@ def test_matter_power_spectrum_cb():
 
     # non-linear
     perturbations_nl = CAMBNonLinearPerturbations(
-        background, np.linspace(0.0, 2.0, 100)
+        background, None, np.linspace(0.0, 2.0, 100)
     )
     assert_allclose(
         perturbations_nl.matter_power_spectrum(0, 1), 736.010737, rtol=1.0e-03

--- a/tests/test_camb_photo_z0_compatibility.py
+++ b/tests/test_camb_photo_z0_compatibility.py
@@ -48,7 +48,7 @@ def camb_photo_setup():
     # User redshifts WITHOUT z=0 (z=0 should be added automatically)
     # Use same grid as tracer for compatibility
     user_z = tracer_z
-    perturbations = CAMBNonLinearPerturbations(background, user_z)
+    perturbations = CAMBNonLinearPerturbations(background, None, user_z)
     n_z_bins = 2
     dndz = np.ones((n_z_bins, len(tracer_z)))
     dndz /= np.trapezoid(dndz, tracer_z, axis=1)[:, None]

--- a/tests/test_class_cosmology.py
+++ b/tests/test_class_cosmology.py
@@ -339,7 +339,10 @@ def class_perturbation_instances(class_background_instance, zs, scope="module"):
         background=class_background_instance, redshifts=zs
     )
     class_non = CLASSNonLinearPerturbations(
-        background=class_background_instance, redshifts=zs, nonlinear_model="halofit"
+        background=class_background_instance,
+        linearperturbations=None,
+        redshifts=zs,
+        nonlinear_model="halofit",
     )
     return {"Linear": class_lin, "NonLinear": class_non}
 
@@ -401,7 +404,10 @@ def test_class_sigma8_consistency_linear_vs_nonlinear(class_background_instance,
         background=class_background_instance, redshifts=zs
     )
     class_non = CLASSNonLinearPerturbations(
-        background=class_background_instance, redshifts=zs, nonlinear_model="halofit"
+        background=class_background_instance,
+        linearperturbations=None,
+        redshifts=zs,
+        nonlinear_model="halofit",
     )
     assert np.abs(class_lin.sigma8_0() - class_non.sigma8_0()) < 1e-3
 
@@ -555,7 +561,7 @@ def class_nonlin_perturb_instance(class_background_instance):
 
     # ----- instantiate perturbations ---------------------------------
     pert = CLASSNonLinearPerturbations(
-        background=class_background_instance, redshifts=zs
+        background=class_background_instance, linearperturbations=None, redshifts=zs
     )
 
     return pert
@@ -578,7 +584,7 @@ def class_nonlin_perturb_instance_nu(class_background_instance):
     class_background_instance.interface_args["CLASSparams"]["m_ncdm"] = 0.2
     # ----- instantiate perturbations ---------------------------------
     pert = CLASSNonLinearPerturbations(
-        background=class_background_instance, redshifts=zs
+        background=class_background_instance, linearperturbations=None, redshifts=zs
     )
 
     return pert

--- a/tests/test_cmb.py
+++ b/tests/test_cmb.py
@@ -41,7 +41,7 @@ def camb_cmb_setup():
 
     z_auto = np.linspace(0.01, 1100.0, 100)
     z_cross = np.linspace(0.2, 2.0, 40)
-    perturbations = CAMBNonLinearPerturbations(background, z_auto)
+    perturbations = CAMBNonLinearPerturbations(background, None, z_auto)
     n_z_bins = 1
     dndz = np.ones((n_z_bins, len(z_cross)))
     dndz /= np.trapezoid(dndz, z_cross, axis=1)[:, None]


### PR DESCRIPTION


## 🚀 Pull Request Checklist

### ✅ Summary

`cloelike` calls `NonLinPerturbations` with the signature `(background, linearperturbations, redshifts, log10TAGN)` to support emulator-based classes that compute nonlinear boosts from pre-computed linear power spectra. 
`CAMBNonLinearPerturbations` was missing the `linearperturbations` argument, making it incompatible with the inference pipeline. This PR adds `linearperturbations` as a mock parameter — CAMB computes nonlinear corrections internally and does not use it.

### 🔄 Changes


- Added `linearperturbations` positional argument to `CAMBNonLinearPerturbations.__init__ `for interface compatibility with `cloelike`
- Updated docstring to explain that `linearperturbations` is accepted but unused by CAMB

### 🛠 How to Test

```python
from cloelib.cosmology.camb_cosmology import CAMBBackground, CAMBLinearPerturbations, CAMBNonLinearPerturbations
import numpy as np

bg = CAMBBackground(H0=67.0, Omega_b0=0.049, Omega_cdm0=0.270, Omega_k0=0.0,
                    As=2.1e-9, ns=0.96, mnu=0.06, w0=-1.0, wa=0.0,
                    gamma_MG=0.0, N_mnu=1)
zs = np.linspace(0.01, 2.0, 10)
lp = CAMBLinearPerturbations(bg, zs)
nlp = CAMBNonLinearPerturbations(bg, lp, zs)
print(nlp.sigma8_0())  # expected: ~0.816

 ```

### 📝 Documentation

- [x] This PR updates documentation

### 🏗 Related Issues

Resolves #476

### 📌 Additional Notes

The corresponding comment explaining this interface contract has been added to `cloelike/EuclidLikelihood_photo_Cls.py` in a companion PR in the `cloelike` repository.

---

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [x] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [ ] I have added unit tests (if applicable)
- [x] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [ ] The next PR targets the correct branch
- [ ] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [ ] Coverage percentage is retained or increased
- [ ] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [ ] No data files have been included in the commits
- [ ] Implementation follows the agreed task description point by point
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the documentation has been updated accordantly
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
