### PR TITLE
gh-503: Fixed squeezing and rescaling

### DIFF
--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -60,9 +60,6 @@ def format_output(stat: str):
                     scale_h = mixing_matrix.kout
                     for key in [0, 2, 4]:
                         rescaled_mixing_matrix.kin[key] = mixing_matrix.kin[key] * h_fid
-                        rescaled_mixing_matrix.kout[key] = (
-                            mixing_matrix.kout[key] * h_fid
-                        )
                         set_arg("mixing_matrix", 0, rescaled_mixing_matrix)
                 else:
                     scale_h = get_arg("k", 0)
@@ -85,7 +82,7 @@ def format_output(stat: str):
                 out = (
                     np.array(
                         [
-                            result.get(f"ell{i}", np.zeros(len(scale_h))).reshape(-1)
+                            result.get(f"ell{i}", np.zeros(len(scale_h)))
                             for i in range(5)
                         ]
                     )


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

After recent PR in euclidlib, there is no longer need of squeezing the output pk multipoles when using the cosmolib format. Additionally the rescaling of kout was not correct in the first place, but this turned out not to be needed. Therefore this PR has removed those implementations

### 🔄 Changes

<!-- List the major changes in this PR. Bullet points preferred. -->

- Removed squeezing of convolved pk multipoles (when using cosmolib format)
- Removed recsaling of kout

### 🏗 Related Issues

Resolves #503

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [ ] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [ ] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [ ] I have added unit tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [ ] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [x] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [ ] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it
