### PR TITLE
gh-435: Fix failing test in classy > 3.3.1, upgrade classy to v3.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 camb = ["camb==1.6.5"]
-classy = ["classy==3.3.1"]
+classy = ["classy==3.3.4"]
 comet-emu = ["comet-emu"]
 hmcode2020emu = ["HMcode2020Emu @ git+https://github.com/MariaTsedrik/HMcode2020Emu.git"]
 euclidemu2 = ["euclidemu2==1.4.3"]

--- a/tests/test_class_cosmology.py
+++ b/tests/test_class_cosmology.py
@@ -63,7 +63,8 @@ def test_class_background_required_attributes(class_background_instance):
     attributes_found = {
         name
         for name, value in contents
-        if not callable(value) and not name.startswith("_")
+        if (not callable(value) or (callable(value) and isinstance(value, float)))
+        and not name.startswith("_")
     }
     assert attributes_required <= attributes_found
 


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

In classy v3.3.2 onwards, the attributes such as cosmo.Neff and cosmo.rdrag have been changed to floats instead of methods. But for backwards compatibility, these floats are made callable. So e.g. both cosmo.Neff and cosmo.Neff() return the same float. This gave rise to a failing test which assumed that the attribute was either callable or a float but not both. After modifying this test, the latest classy v3.3.4 is passing all tests for protocol compliance.

### 🔄 Changes

<!-- List the major changes in this PR. Bullet points preferred. -->

- Fix failing test due to callable floats in classy > 3.3.1
- Update classy version from 3.3.1 to 3.3.4 in pyproject.toml

### 🛠 How to Test

<!-- Provide steps to test the changes. Include commands if applicable. -->

### 📝 Documentation

- [ ] This PR updates documentation
- [ ] This PR does not require documentation changes
- [ ] Issue created for documentation update: Don't forget to link the task!

### 🏗 Related Issues

<!-- Link related issues. Use closing keywords if applicable. -->

Resolves   #435

### 📸 Screenshots (if applicable)

<!-- Upload screenshots to show scientific plots or other graphics -->

### 📌 Additional Notes

<!-- Add any additional context, comments, or concerns here. -->

---

### ✅ PR Checklist for Developers

- [x] I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- [x] I have run locally pre-commit using `pre-commit run --all-files`
- [x] I have tested my changes locally
- [x] No new warnings or errors introduced
- [ ] I have updated documentation (if applicable)
- [x] My changes do not introduce breaking changes (i.e: the package still gets installed)
- [x] I have added unit tests (if applicable)
- [ ] I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [x] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [x] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [x] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [x] Check that any added folder/file has been added to the `README.md` file
- [x] Check that the documentation has been updated accordantly
- [x] Check that the corresponding branch has been deleted after merging. If not, delete it
