### PR TITLE
gh-555: Change defaults for FFTLog settings

### DIFF
--- a/cloelib/summary_statistics/legendre_multipoles.py
+++ b/cloelib/summary_statistics/legendre_multipoles.py
@@ -574,10 +574,10 @@ class LegendreMultipoles:
         s: np.ndarray,
         ells: Optional[np.ndarray] = None,
         use_AP: Optional[bool] = True,
-        logkmin: Optional[float] = -5.0,
+        logkmin: Optional[float] = -6.0,
         logkmax: Optional[float] = 2.0,
         nk: Optional[int] = 2048,
-        kcut: Optional[float] = 0.4,
+        kcut: Optional[float] = 2.0,
         pow: Optional[float] = 2.0,
         format_type: Optional[str] = None,
     ) -> dict:
@@ -637,10 +637,10 @@ class LegendreMultipoles:
         s: np.ndarray,
         mu: np.ndarray,
         use_AP: Optional[bool] = True,
-        logkmin: Optional[float] = -5.0,
+        logkmin: Optional[float] = -6.0,
         logkmax: Optional[float] = 2.0,
         nk: Optional[int] = 2048,
-        kcut: Optional[float] = 0.4,
+        kcut: Optional[float] = 2.0,
         pow: Optional[float] = 2.0,
         format_type: Optional[str] = None,
     ) -> dict:
@@ -691,10 +691,10 @@ class LegendreMultipoles:
         term_list: list,
         ells: Optional[np.ndarray] = None,
         use_AP: Optional[bool] = True,
-        logkmin: Optional[float] = -5.0,
+        logkmin: Optional[float] = -6.0,
         logkmax: Optional[float] = 2.0,
         nk: Optional[int] = 2048,
-        kcut: Optional[float] = 0.4,
+        kcut: Optional[float] = 2.0,
         pow: Optional[float] = 2.0,
     ) -> dict:
         r"""Two-point correlation function Legendre multipoles of specified terms.


### PR DESCRIPTION
## 🚀 Pull Request Checklist

### ✅ Summary

This pull request will instantiate consistency with an internal test of FFTLog settings.

### 🔄 Changes

- Reduces the damping of high-k modes by changing the damping scales from k_*=0.4Mpc^(-1) to k_*=2.0Mpc^(-1)
- Extends the low-k sampling to log(k*Mpc)=-6

### 🛠 How to Test

Just calling the method to predict 2PCF statistics in `legendre_multipoles.py` should work.

### 📝 Documentation

- x This PR updates documentation
- x This PR does not require documentation changes
- x Issue created for documentation update: Don't forget to link the task!

### 🏗 Related Issues

Resolves #555 


### 📌 Additional Notes

🔴 **Note that this change will also affect (and break) the unit tests of the 2PCF likelihood in cloelike. Those need to be changed subsequently.**

---

### ✅ PR Checklist for Developers

- ✔️  I have titled this PR before merging as "gh-#:", where "#" represents the task it closes
- ✔️  I have run locally pre-commit using `pre-commit run --all-files`
- x I have tested my changes locally
- ✔️  No new warnings or errors introduced
- x  I have updated documentation (if applicable) - docstrings & instructions in `cloelib/docs/`
- ✔️  My changes do not introduce breaking changes (i.e: the package still gets installed)
- x  I have added unit tests (if applicable)
- x I have consistently updated the GitHub information for the project, including milestones, task types, and other relevant details.

### ✅ PR Checklist for Reviewers

- [x] The next PR targets the correct branch
- [x] CI tests have run and passed for the latest commit on the source branch
- [x] Check that the code can still be installed if new packages are imported
- [ ] If necessary, the notebooks in the `playground` will be updated in a corresponding follow-up PR
- [x] Coverage percentage is retained or increased
- [x] Quality of new/changed code is acceptable
- [x] Quality of new/changed unit tests is acceptable
- [x] No data files have been included in the commits
- [x] Implementation follows the agreed task description point by point
- [ ] Check that any added folder/file has been added to the `README.md` file
- [ ] Check that the documentation has been updated accordantly (docstrings & instructions in `cloelib/docs/`)
- [ ] Check that the corresponding branch has been deleted after merging. If not, delete it
