### PR TITLE
gh-572: Fix CosmoPower-JAX compatibility with NumPy 2

### DIFF
--- a/cloelib/cosmology/cosmopower_jax_cosmology.py
+++ b/cloelib/cosmology/cosmopower_jax_cosmology.py
@@ -199,7 +199,7 @@ class CosmoPowerJAXw0waCDMPerturbations:
                 self.params["mnu"] = self.background.mnu
 
             for key in self.params.keys():
-                if np.product(self.params[key] - cp_bounds[key]) > 0:
+                if np.prod(self.params[key] - cp_bounds[key]) > 0:
                     raise ValueError(f"Parameter {key} out of emulator range.")
                 else:
                     self.params[key] = np.tile(self.params[key], len(redshifts))
@@ -412,7 +412,7 @@ class CosmoPowerJAXw0waCDMPerturbations:
                 self.params["mnu"] = self.background.mnu
 
             for key in self.params.keys():
-                if np.product(self.params[key] - cp_bounds[key]) > 0:
+                if np.prod(self.params[key] - cp_bounds[key]) > 0:
                     raise ValueError(f"Parameter {key} out of emulator range.")
                 else:
                     self.params[key] = np.tile(self.params[key], len(redshifts))
@@ -586,7 +586,7 @@ class CosmoPowerJAXw0waCDMPerturbations:
                 self.params["mnu"] = self.background.mnu
 
             for key in self.params.keys():
-                if np.product(self.params[key] - cp_bounds[key]) > 0:
+                if np.prod(self.params[key] - cp_bounds[key]) > 0:
                     raise ValueError(f"Parameter {key} out of emulator range.")
                 else:
                     self.params[key] = np.tile(self.params[key], len(redshifts))


### PR DESCRIPTION
## Summary

Replace three uses of the removed `np.product` alias with `np.prod` in the CosmoPower-JAX backend.

The project requires `numpy>2.0`, where `np.product` is no longer available.

Fixes #572.

## Testing

```bash
python -m pytest tests/test_cosmopower_jax_emulators.py
```

Result: 80 passed.